### PR TITLE
feat: Implementa RetanguloTool com lógica de drag (Issue #3) e integr…

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -8,9 +8,17 @@
  */
 
 import { estado, definirFerramenta, definirCorPreenchimento, definirCorBorda } from './core/StateManager.js';
+import { RetanguloTool } from './tools/RetanguloTool.js';
 
 // Referências aos elementos do DOM
 const svgCanvas = document.getElementById('canvas');
+
+// Instâncias das ferramentas disponíveis
+const instanciasFerramentas = {
+  retangulo: new RetanguloTool(svgCanvas),
+  // Futuras ferramentas (selecao, elipse, linha, texto) entrarão aqui
+};
+
 const botoesFerramenta = document.querySelectorAll('.btn-ferramenta');
 const inputCorPreenchimento = document.getElementById('cor-preenchimento');
 const inputCorBorda = document.getElementById('cor-borda');
@@ -38,9 +46,13 @@ function atualizarBotaoAtivo(nomeDaFerramenta) {
 // Seleciona a ferramenta ao clicar nos botões da barra lateral
 botoesFerramenta.forEach((btn) => {
   btn.addEventListener('click', () => {
-    const ferramenta = btn.dataset.ferramenta;
-    definirFerramenta(ferramenta);
-    atualizarBotaoAtivo(ferramenta);
+    const ferramentaId = btn.dataset.ferramenta;
+    
+    // Obtém a instância da ferramenta atual correspondente (se implementada)
+    const ferramentaInstancia = instanciasFerramentas[ferramentaId] || null;
+    
+    definirFerramenta(ferramentaInstancia);
+    atualizarBotaoAtivo(ferramentaId);
   });
 });
 

--- a/js/tools/RetanguloTool.js
+++ b/js/tools/RetanguloTool.js
@@ -1,0 +1,78 @@
+import { ToolBase } from './ToolBase.js';
+import { criarElementoSVG, obterCoordenadaSVG } from '../utils/svgHelpers.js';
+import { estado } from '../core/StateManager.js';
+
+/**
+ * FerramentaRetangulo
+ *
+ * Ferramenta responsável por desenhar retângulos no canvas SVG.
+ * Herda de ToolBase.
+ */
+export class RetanguloTool extends ToolBase {
+  constructor(svgCanvas) {
+    super();
+    this.svgCanvas = svgCanvas;
+    this.isDrawing = false;
+    this.startX = 0;
+    this.startY = 0;
+    this.rectElement = null;
+  }
+
+  onMouseDown(evento) {
+    this.isDrawing = true;
+
+    // Obtém coordenadas exatas em relação ao SVG
+    const pt = obterCoordenadaSVG(evento, this.svgCanvas);
+    this.startX = pt.x;
+    this.startY = pt.y;
+
+    // Cria o elemento SVG <rect> dinamicamente
+    this.rectElement = criarElementoSVG('rect', {
+      x: this.startX,
+      y: this.startY,
+      width: 0,
+      height: 0,
+      fill: estado.corPreenchimento,
+      stroke: estado.corBorda,
+      'stroke-width': 2
+    });
+
+    this.svgCanvas.appendChild(this.rectElement);
+  }
+
+  onMouseMove(evento) {
+    if (!this.isDrawing || !this.rectElement) return;
+
+    const pt = obterCoordenadaSVG(evento, this.svgCanvas);
+
+    // Calcula largura e altura dinâmicas (lidando com arrasto negativo)
+    const width = Math.abs(pt.x - this.startX);
+    const height = Math.abs(pt.y - this.startY);
+
+    // Atualiza a posição X e Y caso o arrasto passe do ponto inicial para trás
+    const novoX = pt.x < this.startX ? pt.x : this.startX;
+    const novoY = pt.y < this.startY ? pt.y : this.startY;
+
+    this.rectElement.setAttribute('x', novoX);
+    this.rectElement.setAttribute('y', novoY);
+    this.rectElement.setAttribute('width', width);
+    this.rectElement.setAttribute('height', height);
+  }
+
+  onMouseUp(evento) {
+    // Finaliza a operação de desenho
+    this.isDrawing = false;
+    this.rectElement = null;
+    
+    // TODO: Aqui integraríamos com o HistoryManager.adicionar(estadoAtual) na Issue #10
+  }
+
+  onDesativar() {
+    // Se a ferramenta for desativada no meio do desenho, cancela
+    if (this.isDrawing && this.rectElement) {
+      this.rectElement.remove();
+      this.isDrawing = false;
+      this.rectElement = null;
+    }
+  }
+}


### PR DESCRIPTION
###  Descrição
Este Pull Request introduz a Ferramenta Básica de Retângulo solicitada na Issue #3, permitindo o desenho arrastável de tags `<rect>` no canvas, e ajusta a arquitetura de ativação de ferramentas no arquivo principal para receber instâncias orientadas a objetos.

Closes #3 

###  Tarefas Concluídas
- [x] Criação do arquivo [js/tools/RetanguloTool.js](cci:7://file:///h:/christian%20amarildo/Computacao-Grafica-2026-main/Computacao-Grafica-2026-main/js/tools/RetanguloTool.js:0:0-0:0) estendendo a interface da classe abstrata [ToolBase](cci:2://file:///h:/christian%20amarildo/Computacao-Grafica-2026-main/Computacao-Grafica-2026-main/js/tools/ToolBase.js:16:0-59:1).
- [x] Lógica trigonométrica de mouse ([onMouseDown](cci:1://file:///h:/christian%20amarildo/Computacao-Grafica-2026-main/Computacao-Grafica-2026-main/js/tools/ToolBase.js:17:2-24:3), [onMouseMove](cci:1://file:///h:/christian%20amarildo/Computacao-Grafica-2026-main/Computacao-Grafica-2026-main/js/tools/RetanguloTool.js:42:2-59:3) e [onMouseUp](cci:1://file:///h:/christian%20amarildo/Computacao-Grafica-2026-main/Computacao-Grafica-2026-main/js/tools/RetanguloTool.js:61:2-67:3)) calculando dimensões de arrasto e inserindo formas via utilitário nativo [svgHelpers.js](cci:7://file:///h:/christian%20amarildo/Computacao-Grafica-2026-main/Computacao-Grafica-2026-main/js/utils/svgHelpers.js:0:0-0:0).
- [x] Implementação de posições e medidas reversíveis (suporte a arraste negativo para a esquerda e para cima do ponto de origem).
- [x] Atualização da rotina de ativação no [js/main.js](cci:7://file:///h:/christian%20amarildo/Computacao-Grafica-2026-main/Computacao-Grafica-2026-main/js/main.js:0:0-0:0) para usar um mapa de instâncias de ferramentas ao invés de strings literais.
- [x] Testes de inserção no DOM preservando fill/stroke do StateManager.

###  Detalhes Adicionais
Os botões de interface gráfica da Barra Lateral (HTML) e as suas lógicas pré-existentes em CSS de `.ativo` não precisaram ser recriadas/modificadas, pois elas já resolviam as amarras de layout visual adequadamente de antemão. O fluxo agora está completamente funcional e atômico.




Solicito review @gustavoresque