### PR TITLE
Adiciona ferramenta ColorPickerTool

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,11 +1,13 @@
 <!DOCTYPE html>
 <html lang="pt-BR">
+
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Editor Vetorial — Computação Gráfica 2026</title>
   <link rel="stylesheet" href="css/style.css" />
 </head>
+
 <body>
   <div id="app">
 
@@ -39,17 +41,22 @@
         <button class="btn-ferramenta" data-ferramenta="texto" title="Texto (T)">
           T
         </button>
+        <button class="btn-ferramenta" data-ferramenta="Conta-gotas" title="Conta-gotas">
+          <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none"
+            stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
+            class="lucide lucide-pipette-icon lucide-pipette">
+            <path
+              d="m12 9-8.414 8.414A2 2 0 0 0 3 18.828v1.344a2 2 0 0 1-.586 1.414A2 2 0 0 1 3.828 21h1.344a2 2 0 0 0 1.414-.586L15 12" />
+            <path d="m18 9 .4.4a1 1 0 1 1-3 3l-3.8-3.8a1 1 0 1 1 3-3l.4.4 3.4-3.4a1 1 0 1 1 3 3z" />
+            <path d="m2 22 .414-.414" />
+          </svg>
+        </button>
       </aside>
 
       <!-- Área Central de Desenho -->
       <main id="area-desenho">
-        <svg
-          id="canvas"
-          xmlns="http://www.w3.org/2000/svg"
-          width="100%"
-          height="100%"
-          aria-label="Área de desenho vetorial"
-        >
+        <svg id="canvas" xmlns="http://www.w3.org/2000/svg" width="100%" height="100%"
+          aria-label="Área de desenho vetorial">
           <!-- Os elementos SVG criados pelo usuário serão inseridos aqui -->
         </svg>
       </main>
@@ -60,4 +67,5 @@
   <!-- Ponto de entrada da aplicação: ES6 Module -->
   <script type="module" src="js/main.js"></script>
 </body>
+
 </html>

--- a/js/main.js
+++ b/js/main.js
@@ -8,6 +8,7 @@
  */
 
 import { estado, definirFerramenta, definirCorPreenchimento, definirCorBorda } from './core/StateManager.js';
+import { ColorPickerTool } from './tools/ColorPickerTool.js';
 import { RetanguloTool } from './tools/RetanguloTool.js';
 
 // Referências aos elementos do DOM
@@ -16,6 +17,7 @@ const svgCanvas = document.getElementById('canvas');
 // Instâncias das ferramentas disponíveis
 const instanciasFerramentas = {
   retangulo: new RetanguloTool(svgCanvas),
+  "Conta-gotas": new ColorPickerTool(svgCanvas),
   // Futuras ferramentas (selecao, elipse, linha, texto) entrarão aqui
 };
 

--- a/js/tools/ColorPickerTool.js
+++ b/js/tools/ColorPickerTool.js
@@ -1,0 +1,9 @@
+import { ToolBase } from "./ToolBase.js";
+
+export class ColorPickerTool extends ToolBase {
+  /** @param {SVGSVGElement} svgCanvas */
+  constructor(svgCanvas) {
+    super();
+    this.svgCanvas = svgCanvas;
+  }
+}

--- a/js/tools/ColorPickerTool.js
+++ b/js/tools/ColorPickerTool.js
@@ -13,14 +13,18 @@ export class ColorPickerTool extends ToolBase {
   /** @param {MouseEvent} evento*/
   onMouseDown(evento) {
     const elemento = document.elementFromPoint(evento.x, evento.y);
-    if (!(elemento instanceof SVGGeometryElement)) return;
-    const point = obterCoordenadaSVG(evento, this.svgCanvas);
-    const isInStroke = elemento.isPointInStroke(point);
-    const style = window.getComputedStyle(elemento);
-    const color =
-      isInStroke && style.stroke !== "none" ? style.stroke : style.fill;
-    definirCorPreenchimento(color);
+    /** @type {string} */ let color;
 
+    if (elemento instanceof SVGGeometryElement) {
+      const point = obterCoordenadaSVG(evento, this.svgCanvas);
+      const isInStroke = elemento.isPointInStroke(point);
+      const style = window.getComputedStyle(elemento);
+      color = isInStroke && style.stroke !== "none" ? style.stroke : style.fill;
+    } else {
+      color = elemento.computedStyleMap().get("background-color").toString();
+    }
+
+    definirCorPreenchimento(color);
     const corInput =
       /** @type {HTMLInputElement} */
       (document.getElementById("cor-preenchimento"));

--- a/js/tools/ColorPickerTool.js
+++ b/js/tools/ColorPickerTool.js
@@ -11,31 +11,35 @@ export class ColorPickerTool extends ToolBase {
   constructor(svgCanvas) {
     super();
     this.svgCanvas = svgCanvas;
+    this.detectedColor = "";
     /** @type {Set<string>} */
     this.pressedKeys = new Set();
     const listenKey = (/** @type {string} */ key) => {
       const onKeyDown = (/** @type {KeyboardEvent} */ event) => {
         if (event.key === key) {
-          console.log(key, "down");
           this.pressedKeys.add(key);
         }
       };
       const onKeyUp = (/** @type {KeyboardEvent} */ event) => {
         if (event.key === key) {
-          console.log(key, "up");
           this.pressedKeys.delete(key);
         }
       };
       return { onKeyDown, onKeyUp };
     };
     this.listeners = ["Control", "Shift", "c"].flatMap(listenKey);
-    this.detectedColor = null;
   }
 
   onAtivar() {
     this.listeners.forEach((keyListeners) => {
       window.addEventListener("keydown", keyListeners.onKeyDown);
       window.addEventListener("keyup", keyListeners.onKeyUp);
+    });
+
+    window.addEventListener("keydown", () => {
+      if (this.pressedKeys.has("Control") && this.pressedKeys.has("c")) {
+        navigator.clipboard.writeText(this.detectedColor);
+      }
     });
   }
 
@@ -47,7 +51,7 @@ export class ColorPickerTool extends ToolBase {
   }
 
   /** @param {MouseEvent} evento*/
-  onMouseDown(evento) {
+  onMouseMove(evento) {
     const elemento = document.elementFromPoint(evento.x, evento.y);
     /** @type {string} */ let color;
 
@@ -60,20 +64,25 @@ export class ColorPickerTool extends ToolBase {
       color = elemento.computedStyleMap().get("background-color").toString();
     }
 
-    const hexColor = rgbToHex(color);
+    this.detectedColor = rgbToHex(color);
+  }
 
+  /**
+   * @param {MouseEvent} evento
+   */
+  onMouseDown(evento) {
     if (this.pressedKeys.has("Shift")) {
-      definirCorBorda(color);
+      definirCorBorda(this.detectedColor);
       const bordaInput =
         /** @type {HTMLInputElement} */
         (document.getElementById("cor-borda"));
-      bordaInput.value = hexColor;
+      bordaInput.value = this.detectedColor;
     } else {
-      definirCorPreenchimento(color);
+      definirCorPreenchimento(this.detectedColor);
       const preenchimentoInput =
         /** @type {HTMLInputElement} */
         (document.getElementById("cor-preenchimento"));
-      preenchimentoInput.value = hexColor;
+      preenchimentoInput.value = this.detectedColor;
     }
   }
 }

--- a/js/tools/ColorPickerTool.js
+++ b/js/tools/ColorPickerTool.js
@@ -1,3 +1,6 @@
+import { definirCorPreenchimento } from "../core/StateManager.js";
+import { rgbToHex } from "../utils/colorHelpers.js";
+import { obterCoordenadaSVG } from "../utils/svgHelpers.js";
 import { ToolBase } from "./ToolBase.js";
 
 export class ColorPickerTool extends ToolBase {
@@ -5,5 +8,22 @@ export class ColorPickerTool extends ToolBase {
   constructor(svgCanvas) {
     super();
     this.svgCanvas = svgCanvas;
+  }
+
+  /** @param {MouseEvent} evento*/
+  onMouseDown(evento) {
+    const elemento = document.elementFromPoint(evento.x, evento.y);
+    if (!(elemento instanceof SVGGeometryElement)) return;
+    const point = obterCoordenadaSVG(evento, this.svgCanvas);
+    const isInStroke = elemento.isPointInStroke(point);
+    const style = window.getComputedStyle(elemento);
+    const color =
+      isInStroke && style.stroke !== "none" ? style.stroke : style.fill;
+    definirCorPreenchimento(color);
+
+    const corInput =
+      /** @type {HTMLInputElement} */
+      (document.getElementById("cor-preenchimento"));
+    corInput.value = rgbToHex(color);
   }
 }

--- a/js/tools/ColorPickerTool.js
+++ b/js/tools/ColorPickerTool.js
@@ -11,29 +11,39 @@ export class ColorPickerTool extends ToolBase {
   constructor(svgCanvas) {
     super();
     this.svgCanvas = svgCanvas;
-    this.shiftPressed = false;
-
-    this.onShiftDown = (/** @type {KeyboardEvent} */ event) => {
-      if (event.key === "Shift") {
-        this.shiftPressed = true;
-      }
+    /** @type {Set<string>} */
+    this.pressedKeys = new Set();
+    const listenKey = (/** @type {string} */ key) => {
+      const onKeyDown = (/** @type {KeyboardEvent} */ event) => {
+        if (event.key === key) {
+          console.log(key, "down");
+          this.pressedKeys.add(key);
+        }
+      };
+      const onKeyUp = (/** @type {KeyboardEvent} */ event) => {
+        if (event.key === key) {
+          console.log(key, "up");
+          this.pressedKeys.delete(key);
+        }
+      };
+      return { onKeyDown, onKeyUp };
     };
-
-    this.onShiftUp = (/** @type {KeyboardEvent} */ event) => {
-      if (event.key === "Shift") {
-        this.shiftPressed = false;
-      }
-    };
+    this.listeners = ["Control", "Shift", "c"].flatMap(listenKey);
+    this.detectedColor = null;
   }
 
   onAtivar() {
-    window.addEventListener("keydown", this.onShiftDown);
-    window.addEventListener("keyup", this.onShiftUp);
+    this.listeners.forEach((keyListeners) => {
+      window.addEventListener("keydown", keyListeners.onKeyDown);
+      window.addEventListener("keyup", keyListeners.onKeyUp);
+    });
   }
 
   onDesativar() {
-    window.removeEventListener("keydown", this.onShiftDown);
-    window.removeEventListener("keyup", this.onShiftUp);
+    this.listeners.forEach((keyListeners) => {
+      window.removeEventListener("keydown", keyListeners.onKeyDown);
+      window.removeEventListener("keyup", keyListeners.onKeyUp);
+    });
   }
 
   /** @param {MouseEvent} evento*/
@@ -52,7 +62,7 @@ export class ColorPickerTool extends ToolBase {
 
     const hexColor = rgbToHex(color);
 
-    if (this.shiftPressed) {
+    if (this.pressedKeys.has("Shift")) {
       definirCorBorda(color);
       const bordaInput =
         /** @type {HTMLInputElement} */

--- a/js/tools/ColorPickerTool.js
+++ b/js/tools/ColorPickerTool.js
@@ -1,4 +1,7 @@
-import { definirCorPreenchimento } from "../core/StateManager.js";
+import {
+  definirCorBorda,
+  definirCorPreenchimento,
+} from "../core/StateManager.js";
 import { rgbToHex } from "../utils/colorHelpers.js";
 import { obterCoordenadaSVG } from "../utils/svgHelpers.js";
 import { ToolBase } from "./ToolBase.js";
@@ -8,6 +11,29 @@ export class ColorPickerTool extends ToolBase {
   constructor(svgCanvas) {
     super();
     this.svgCanvas = svgCanvas;
+    this.shiftPressed = false;
+
+    this.onShiftDown = (/** @type {KeyboardEvent} */ event) => {
+      if (event.key === "Shift") {
+        this.shiftPressed = true;
+      }
+    };
+
+    this.onShiftUp = (/** @type {KeyboardEvent} */ event) => {
+      if (event.key === "Shift") {
+        this.shiftPressed = false;
+      }
+    };
+  }
+
+  onAtivar() {
+    window.addEventListener("keydown", this.onShiftDown);
+    window.addEventListener("keyup", this.onShiftUp);
+  }
+
+  onDesativar() {
+    window.removeEventListener("keydown", this.onShiftDown);
+    window.removeEventListener("keyup", this.onShiftUp);
   }
 
   /** @param {MouseEvent} evento*/
@@ -24,10 +50,20 @@ export class ColorPickerTool extends ToolBase {
       color = elemento.computedStyleMap().get("background-color").toString();
     }
 
-    definirCorPreenchimento(color);
-    const corInput =
-      /** @type {HTMLInputElement} */
-      (document.getElementById("cor-preenchimento"));
-    corInput.value = rgbToHex(color);
+    const hexColor = rgbToHex(color);
+
+    if (this.shiftPressed) {
+      definirCorBorda(color);
+      const bordaInput =
+        /** @type {HTMLInputElement} */
+        (document.getElementById("cor-borda"));
+      bordaInput.value = hexColor;
+    } else {
+      definirCorPreenchimento(color);
+      const preenchimentoInput =
+        /** @type {HTMLInputElement} */
+        (document.getElementById("cor-preenchimento"));
+      preenchimentoInput.value = hexColor;
+    }
   }
 }

--- a/js/utils/colorHelpers.js
+++ b/js/utils/colorHelpers.js
@@ -1,0 +1,19 @@
+const COLOR_COMPONENTS_REGEX = /\d+/g;
+
+/**
+ * Coverte uma string de cor RGB dos formatos
+ * - rgb(0, 0, 0)
+ * - (0, 0, 0)
+ *
+ * Para o formato hexadecimal #000000
+ *
+ * @param {string} rgb
+ */
+export function rgbToHex(rgb) {
+  const colorComponents = Array.from(
+    rgb.matchAll(COLOR_COMPONENTS_REGEX),
+  ).flatMap((match) => parseInt(match[0]));
+  const colorComponentsHex = colorComponents.map((color) => color.toString(16));
+  const hexString = `#${colorComponentsHex.join("")}`;
+  return hexString;
+}

--- a/js/utils/colorHelpers.js
+++ b/js/utils/colorHelpers.js
@@ -13,7 +13,9 @@ export function rgbToHex(rgb) {
   const colorComponents = Array.from(
     rgb.matchAll(COLOR_COMPONENTS_REGEX),
   ).flatMap((match) => parseInt(match[0]));
-  const colorComponentsHex = colorComponents.map((color) => color.toString(16));
+  const colorComponentsHex = colorComponents.map((color) =>
+    color.toString(16).padStart(2, "0"),
+  );
   const hexString = `#${colorComponentsHex.join("")}`;
   return hexString;
 }


### PR DESCRIPTION
Cria a classe ColorPickerTool e registra a ferramenta.

Quando o usuário clica sobre o canvas, a ferramenta seleciona o elemento na posição do cursor.
Baseado na posição, a ferramenta detecta se o que está sob o cursor é o preenchimento ou o contorno do elemento, se houver.
Ações:
- (Clique): Define a cor detectada como a cor de preenchimento.
- (Clique + Shift): Define a cor detectada como a cor de contorno.

Arquivos criados:
- `ColorPickerTool.js`: Classe da ferramenta.
- `colorHelpers.js`: Utilitário para converter string de cor RGB para hexadecimal.