### PR TITLE
Adiciona jsconfig.json para checagem de tipos e corrige algumas tipagens

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -7,8 +7,13 @@
  *  - Conectar os botões da barra de ferramentas ao StateManager
  */
 
-import { estado, definirFerramenta, definirCorPreenchimento, definirCorBorda } from './core/StateManager.js';
-import { RetanguloTool } from './tools/RetanguloTool.js';
+import {
+  estado,
+  definirFerramenta,
+  definirCorPreenchimento,
+  definirCorBorda,
+} from "./core/StateManager.js";
+import { RetanguloTool } from "./tools/RetanguloTool.js";
 
 // Referências aos elementos do DOM
 const svgCanvas = document.getElementById('canvas');
@@ -20,8 +25,13 @@ const instanciasFerramentas = {
 };
 
 const botoesFerramenta = document.querySelectorAll('.btn-ferramenta');
-const inputCorPreenchimento = document.getElementById('cor-preenchimento');
-const inputCorBorda = document.getElementById('cor-borda');
+const inputCorPreenchimento = /** @type {HTMLInputElement} */ (
+  document.getElementById('cor-preenchimento')
+);
+const inputCorBorda = /** @type {HTMLInputElement} */ (
+  document.getElementById('cor-borda')
+);
+
 const nomeFerramenta = document.getElementById('nome-ferramenta');
 
 /**
@@ -32,7 +42,7 @@ const nomeFerramenta = document.getElementById('nome-ferramenta');
  */
 function atualizarBotaoAtivo(nomeDaFerramenta) {
   botoesFerramenta.forEach((btn) => {
-    if (btn.dataset.ferramenta === nomeDaFerramenta) {
+    if (btn.getAttribute('data-ferramenta') === nomeDaFerramenta) {
       btn.classList.add('ativo');
     } else {
       btn.classList.remove('ativo');
@@ -46,11 +56,11 @@ function atualizarBotaoAtivo(nomeDaFerramenta) {
 // Seleciona a ferramenta ao clicar nos botões da barra lateral
 botoesFerramenta.forEach((btn) => {
   btn.addEventListener('click', () => {
-    const ferramentaId = btn.dataset.ferramenta;
-    
+    const ferramentaId = btn.getAttribute('data-ferramenta');
+
     // Obtém a instância da ferramenta atual correspondente (se implementada)
     const ferramentaInstancia = instanciasFerramentas[ferramentaId] || null;
-    
+
     definirFerramenta(ferramentaInstancia);
     atualizarBotaoAtivo(ferramentaId);
   });
@@ -58,12 +68,12 @@ botoesFerramenta.forEach((btn) => {
 
 // Atualiza a cor de preenchimento no estado global
 inputCorPreenchimento.addEventListener('input', (evento) => {
-  definirCorPreenchimento(evento.target.value);
+  definirCorPreenchimento(inputCorPreenchimento.value);
 });
 
 // Atualiza a cor da borda no estado global
 inputCorBorda.addEventListener('input', (evento) => {
-  definirCorBorda(evento.target.value);
+  definirCorBorda(inputCorBorda.value);
 });
 
 // Event listeners globais do SVG (delegados para a ferramenta ativa)

--- a/js/main.js
+++ b/js/main.js
@@ -22,10 +22,10 @@ const instanciasFerramentas = {
 };
 
 const botoesFerramenta = document.querySelectorAll('.btn-ferramenta');
-const inputCorPreenchimento = /** @type {HTMLInputElement} */ (
+const inputCorPreenchimento = (
   document.getElementById('cor-preenchimento')
 );
-const inputCorBorda = /** @type {HTMLInputElement} */ (
+const inputCorBorda = (
   document.getElementById('cor-borda')
 );
 

--- a/js/utils/svgHelpers.js
+++ b/js/utils/svgHelpers.js
@@ -26,7 +26,7 @@ export function criarElementoSVG(tag, atributos = {}) {
   const elemento = document.createElementNS(SVG_NS, tag);
 
   Object.entries(atributos).forEach(([chave, valor]) => {
-    elemento.setAttribute(chave, valor);
+    elemento.setAttribute(chave, valor.toString());
   });
 
   return elemento;

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,6 @@
+{
+    "compilerOptions": {
+        "target": "es2024",
+        "checkJs": true
+    }
+}


### PR DESCRIPTION
Adiciona o arquivo `jsconfig.json` na raiz do projeto para habilitar a checagem de tipos.

Essa checagem é feita superficialmente e serve principalmente para detectar acesso a propriedades inexistentes ou atribuição de valores a variáveis com tipos incompatíveis.
A tipagem não é obrigatória e não impede a execução do código, servindo mais como uma ferramenta de análise.

Também fiz alguns ajustes no código para resolver problemas detectados.