### PR TITLE
Implementar Ferramenta Básica de Desenho: Ellipse

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -18,7 +18,7 @@ const svgCanvas = document.getElementById('canvas');
 const instanciasFerramentas = {
   retangulo: new RetanguloTool(svgCanvas),
   elipse: new EllipseTool(svgCanvas),
-  // Futuras ferramentas (selecao, elipse, linha, texto) entrarão aqui
+  // Futuras ferramentas (selecao, linha, texto) entrarão aqui
 };
 
 const botoesFerramenta = document.querySelectorAll('.btn-ferramenta');

--- a/js/main.js
+++ b/js/main.js
@@ -9,6 +9,7 @@
 
 import { estado, definirFerramenta, definirCorPreenchimento, definirCorBorda } from './core/StateManager.js';
 import { RetanguloTool } from './tools/RetanguloTool.js';
+import { EllipseTool } from './tools/EllipseTool.js';
 
 // Referências aos elementos do DOM
 const svgCanvas = document.getElementById('canvas');
@@ -16,6 +17,7 @@ const svgCanvas = document.getElementById('canvas');
 // Instâncias das ferramentas disponíveis
 const instanciasFerramentas = {
   retangulo: new RetanguloTool(svgCanvas),
+  elipse: new EllipseTool(svgCanvas),
   // Futuras ferramentas (selecao, elipse, linha, texto) entrarão aqui
 };
 

--- a/js/tools/EllipseTool.js
+++ b/js/tools/EllipseTool.js
@@ -1,5 +1,6 @@
 import { ToolBase } from "./ToolBase.js";
 import { criarElementoSVG, obterCoordenadaSVG } from "../utils/svgHelpers.js";
+import { estado } from "../core/StateManager.js";
 
 export class EllipseTool extends ToolBase {
     constructor(svgCanvas) {
@@ -23,8 +24,8 @@ export class EllipseTool extends ToolBase {
             cy: this.startY,
             rx: 0,
             ry: 0,
-            fill: 'transparent',
-            stroke: 'black',
+            fill: estado.corPreenchimento,
+            stroke: estado.corBorda,
             'stroke-width': 2
         });
 

--- a/js/tools/EllipseTool.js
+++ b/js/tools/EllipseTool.js
@@ -1,0 +1,1 @@
+import { ToolBase } from "./ToolBase";

--- a/js/tools/EllipseTool.js
+++ b/js/tools/EllipseTool.js
@@ -12,6 +12,8 @@ export class EllipseTool extends ToolBase {
     }
 
     onMouseDown(evento) {
+        this.isDrawing = true
+
         const cd = obterCoordenadaSVG(evento, this.svgCanvas);
         this.startX = cd.x;
         this.startY = cd.y;
@@ -25,5 +27,7 @@ export class EllipseTool extends ToolBase {
             stroke: 'black',
             'stroke-width': 2
         });
+
+        this.svgCanvas.appendChild(this.ellipseElement);
     }
 }

--- a/js/tools/EllipseTool.js
+++ b/js/tools/EllipseTool.js
@@ -48,4 +48,11 @@ export class EllipseTool extends ToolBase {
         this.ellipseElement.setAttribute('rx', rx);
         this.ellipseElement.setAttribute('ry', ry);
     }
+
+    onMouseUp(evento) {
+        if (this.isDrawing) {
+            this.isDrawing = false;
+            this.ellipseElement = null
+        }
+    }
 }

--- a/js/tools/EllipseTool.js
+++ b/js/tools/EllipseTool.js
@@ -9,4 +9,8 @@ export class EllipseTool extends ToolBase {
         this.startY = 0
         this.ellipseElement = null
     }
+
+    onMouseDown(evento) {
+        
+    }
 }

--- a/js/tools/EllipseTool.js
+++ b/js/tools/EllipseTool.js
@@ -42,5 +42,10 @@ export class EllipseTool extends ToolBase {
         const cy = (this.startY + currentY) / 2;
         const rx = Math.abs(this.startX - currentX) / 2;
         const ry = Math.abs(this.startY - currentY) / 2;
+
+        this.ellipseElement.setAttribute('cx', cx);
+        this.ellipseElement.setAttribute('cy', cy);
+        this.ellipseElement.setAttribute('rx', rx);
+        this.ellipseElement.setAttribute('ry', ry);
     }
 }

--- a/js/tools/EllipseTool.js
+++ b/js/tools/EllipseTool.js
@@ -55,4 +55,19 @@ export class EllipseTool extends ToolBase {
             this.ellipseElement = null
         }
     }
+
+    onDesativar() {
+        // Se a ferramenta for desativada durante um desenho em andamento,
+        // removemos a elipse parcial e resetamos o estado interno.
+        if (this.isDrawing && this.ellipseElement) {
+            const parent = this.ellipseElement.parentNode;
+            if (parent) {
+                parent.removeChild(this.ellipseElement);
+            }
+        }
+        this.isDrawing = false;
+        this.ellipseElement = null;
+        this.startX = 0;
+        this.startY = 0;
+    }
 }

--- a/js/tools/EllipseTool.js
+++ b/js/tools/EllipseTool.js
@@ -1,1 +1,12 @@
 import { ToolBase } from "./ToolBase";
+
+export class EllipseTool extends ToolBase {
+    constructor(svgCanvas) {
+        super()
+        this.svgCanvas = svgCanvas
+        this.isDrawing = false
+        this.startX = 0
+        this.startY = 0
+        this.ellipseElement = null
+    }
+}

--- a/js/tools/EllipseTool.js
+++ b/js/tools/EllipseTool.js
@@ -1,4 +1,5 @@
 import { ToolBase } from "./ToolBase";
+import { criarElementoSVG, obterCoordenadaSVG } from "../utils/svgHelpers.js";
 
 export class EllipseTool extends ToolBase {
     constructor(svgCanvas) {
@@ -14,5 +15,15 @@ export class EllipseTool extends ToolBase {
         const cd = obterCoordenadaSVG(evento, this.svgCanvas);
         this.startX = cd.x;
         this.startY = cd.y;
+
+        this.ellipseElement = criarElementoSVG('ellipse', {
+            cx: this.startX,
+            cy: this.startY,
+            rx: 0,
+            ry: 0,
+            fill: 'transparent',
+            stroke: 'black',
+            'stroke-width': 2
+        });
     }
 }

--- a/js/tools/EllipseTool.js
+++ b/js/tools/EllipseTool.js
@@ -1,4 +1,4 @@
-import { ToolBase } from "./ToolBase";
+import { ToolBase } from "./ToolBase.js";
 import { criarElementoSVG, obterCoordenadaSVG } from "../utils/svgHelpers.js";
 
 export class EllipseTool extends ToolBase {

--- a/js/tools/EllipseTool.js
+++ b/js/tools/EllipseTool.js
@@ -32,6 +32,10 @@ export class EllipseTool extends ToolBase {
     }
 
     onMouseMove(evento) {
-        
+        if (!this.isDrawing || !this.ellipseElement) return;
+
+        const cd = obterCoordenadaSVG(evento, this.svgCanvas);
+        const currentX = cd.x;
+        const currentY = cd.y;
     }
 }

--- a/js/tools/EllipseTool.js
+++ b/js/tools/EllipseTool.js
@@ -11,6 +11,8 @@ export class EllipseTool extends ToolBase {
     }
 
     onMouseDown(evento) {
-        
+        const cd = obterCoordenadaSVG(evento, this.svgCanvas);
+        this.startX = cd.x;
+        this.startY = cd.y;
     }
 }

--- a/js/tools/EllipseTool.js
+++ b/js/tools/EllipseTool.js
@@ -30,4 +30,8 @@ export class EllipseTool extends ToolBase {
 
         this.svgCanvas.appendChild(this.ellipseElement);
     }
+
+    onMouseMove(evento) {
+        
+    }
 }

--- a/js/tools/EllipseTool.js
+++ b/js/tools/EllipseTool.js
@@ -37,5 +37,10 @@ export class EllipseTool extends ToolBase {
         const cd = obterCoordenadaSVG(evento, this.svgCanvas);
         const currentX = cd.x;
         const currentY = cd.y;
+
+        const cx = (this.startX + currentX) / 2;
+        const cy = (this.startY + currentY) / 2;
+        const rx = Math.abs(this.startX - currentX) / 2;
+        const ry = Math.abs(this.startY - currentY) / 2;
     }
 }


### PR DESCRIPTION
@gustavoresque sobre a Issue #8 

Implementei a ferramenta de desenho geométrico (Ellipse) estendendo a classe base ToolBase.

Critérios satisfeitos:
- [ x ] Criar os arquivos e ```EllipseTool.js``` dentro da pasta tools
- [ x ] Ao selecionar a ferramenta, o usuário deve poder clicar e arrastar no canvas para desenhar a forma em tempo real
- [ x ] Utilizar funções do ```svgHelpers.js``` para criar os elementos SVG com o namespace correto

Arquivo criado: ```EllipseTool.js```, sendo a classe da ellipse e suas funcionalidades
Arquivo modificado: ```main.js```, adicionando a classe da ellipse para implementar nas ferramentas