### PR TITLE
45 feature implementar atalhos do teclado para selecionar as ferramentas

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,7 +41,7 @@
         <button class="btn-ferramenta" data-ferramenta="texto" title="Texto (T)">
           T
         </button>
-        <button class="btn-ferramenta" data-ferramenta="conta-gotas" title="Conta-gotas">
+        <button class="btn-ferramenta" data-ferramenta="conta-gotas" title="Conta-gotas (I)">
           <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none"
             stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
             class="lucide lucide-pipette-icon lucide-pipette">

--- a/index.html
+++ b/index.html
@@ -41,7 +41,7 @@
         <button class="btn-ferramenta" data-ferramenta="texto" title="Texto (T)">
           T
         </button>
-        <button class="btn-ferramenta" data-ferramenta="Conta-gotas" title="Conta-gotas">
+        <button class="btn-ferramenta" data-ferramenta="conta-gotas" title="Conta-gotas">
           <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none"
             stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
             class="lucide lucide-pipette-icon lucide-pipette">

--- a/js/main.js
+++ b/js/main.js
@@ -151,5 +151,19 @@ window.addEventListener("keydown", (e) => {
 
   const teclaPressionada = e.key.toLowerCase();
   const ferramentaAlvo = mapaTeclas[teclaPressionada];
+  
+  // Adicionar e feedback visual
+  if (ferramentaAlvo) {
+    e.preventDefault();
+
+    // Buscar o botão na barra lateral
+    const botao = document.querySelector(`.btn-ferramenta[data-ferramenta="${ferramentaAlvo}"]`);
+
+    if (botao) {
+      // Simular click para utilizar o eventListener que chama `atualizarBotaoAtivo()`
+      // e aplica a classe CSS '.ativo' de forma automática.
+      botao.click();
+    }
   }
+}
 )

--- a/js/main.js
+++ b/js/main.js
@@ -138,5 +138,18 @@ window.addEventListener("keydown", (e) => {
   if (["input", "textarea", "select"].includes(tagAtiva) || elementoAtivo.isContentEditable)
     return;
   
+  // Mapeamento das teclas 
+  // Conforme novas ferramentas forem surgindo, só adicionar o atalho e o nome da ferramenta aqui
+  const mapaTeclas = {
+    "s" : "selecao",
+    "r" : "retangulo",
+    "e" : "elipse",
+    "l" : "linha",
+    "t" : "texto",
+    "i" : "conta-gotas"
+  }
+
+  const teclaPressionada = e.key.toLowerCase();
+  const ferramentaAlvo = mapaTeclas[teclaPressionada];
   }
 )

--- a/js/main.js
+++ b/js/main.js
@@ -130,6 +130,12 @@ svgCanvas.addEventListener('mouseup', (evento) => {
 inputCorPreenchimento.value = estado.corPreenchimento;
 inputCorBorda.value = estado.corBorda;
 
+// Exportar / Salvar desenho
+btnExportar.addEventListener('click', () => {
+  const formato = exportFormat.value || 'png';
+  exportarDesenho(svgCanvas, formato);
+});
+
 // Atalhos de Teclado (Tool Selection)
 window.addEventListener("keydown", (e) => {
   // Prevenção de conflitos

--- a/js/main.js
+++ b/js/main.js
@@ -126,3 +126,9 @@ svgCanvas.addEventListener('mouseup', (evento) => {
 // Inicializa os valores dos inputs com os valores padrão do estado
 inputCorPreenchimento.value = estado.corPreenchimento;
 inputCorBorda.value = estado.corBorda;
+
+// Atalhos de Teclado (Tool Selection)
+window.addEventListener("keydown", (e) => {
+  
+  }
+)

--- a/js/main.js
+++ b/js/main.js
@@ -129,6 +129,14 @@ inputCorBorda.value = estado.corBorda;
 
 // Atalhos de Teclado (Tool Selection)
 window.addEventListener("keydown", (e) => {
+  // Prevenção de conflitos
+  // Verifica se o usuário está focado em um campo de texto ou input de cor.
+  const elementoAtivo = document.activeElement;
+  const tagAtiva = elementoAtivo.tagName.toLocaleLowerCase();
+
+  // Se o foco estiver em um input, textArea, select ou contentEditable, ignora o atalho.
+  if (["input", "textarea", "select"].includes(tagAtiva) || elementoAtivo.isContentEditable)
+    return;
   
   }
 )


### PR DESCRIPTION
**Descrição:**
Este Pull Request implementa a Issue #45, adicionando atalhos de teclado nativos para otimizar o fluxo de trabalho no editor vetorial.

A solução foi construída com foco em manter o código limpo e a experiência do usuário (UX) livre de frustrações:
1. **Prevenção de Conflitos (UX):** Adicionada uma verificação no `document.activeElement`. Se o usuário estiver com o foco em inputs de texto, caixas de cor, selects ou elementos com `contentEditable`, os atalhos são suspensos para permitir a digitação normal.
2. **Arquitetura Don't Repeat Yourself (DRY):** Em vez de reescrever a lógica de ativação de ferramentas, o `EventListener` de teclado faz um mapeamento (Dicionário/Objeto) da tecla pressionada e dispara um `botao.click()` simulado. Isso garante que todo o fluxo de estado global e classes CSS (`.ativo`) da interface sejam atualizados pela mesma via de dados já consolidada na aplicação.

**Ferramentas mapeadas:**
* `S` - Seleção
* `R` - Retângulo
* `E` - Elipse
* `L` - Linha
* `T` - Texto
* `I` - Conta-gotas

**Solicitação de Badge:**
Gostaria de solicitar a badge 🎨 **UI/UX Master** por esta entrega. A inclusão da trava de segurança analisando o `activeElement` previne um problema clássico de usabilidade em editores web (acionar ferramentas enquanto se tenta digitar um valor hexadecimal de cor ou renomear uma camada), garantindo uma navegação muito mais fluida.

Resolves #45 