### PR TITLE
feat(ui): implementar tela inicial de menu e navegação Resolves #46

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -237,3 +237,76 @@ body {
   width: 100%;
   height: 100%;
 }
+
+.oculto {
+  display: none !important;
+}
+
+#tela-inicial {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 100vh;
+  background-color: var(--cor-fundo-app);
+  color: var(--cor-texto);
+}
+
+#tela-inicial h1 {
+  font-size: 2.5rem;
+  margin-bottom: 2rem;
+  color: var(--cor-texto);
+  text-shadow: 0 2px 4px rgba(0,0,0,0.5);
+}
+
+.menu-opcoes {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  background-color: var(--cor-fundo-painel);
+  padding: 32px;
+  border-radius: var(--raio-borda);
+  border: 1px solid var(--cor-borda-ui);
+  box-shadow: var(--sombra-padrao);
+  width: 100%;
+  max-width: 400px;
+}
+
+.grupo-opcao {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
+/* Reutilizando a estrutura de botão para o menu */
+.btn-menu {
+  background-color: transparent;
+  color: var(--cor-texto);
+  border: 1px solid var(--cor-borda-ui);
+  border-radius: var(--raio-borda);
+  padding: 12px 16px;
+  font-size: 16px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  font-family: inherit;
+}
+
+.btn-menu:hover {
+  border-color: var(--cor-destaque);
+  background-color: rgba(74, 144, 217, 0.1);
+  color: var(--cor-destaque);
+}
+
+/* O botão de criar novo documento merece destaque */
+#btn-novo-doc {
+  background-color: var(--cor-destaque);
+  color: #fff;
+  border-color: var(--cor-destaque);
+  font-weight: bold;
+}
+
+#btn-novo-doc:hover {
+  background-color: #3a7bc2; /* Tom levemente mais escuro */
+  transform: translateY(-2px);
+}

--- a/css/style.css
+++ b/css/style.css
@@ -204,8 +204,8 @@ body {
 }
 
 .select-format option {
-    background-color: var(--cor-fundo-painel); /* Usa a cor escura do painel */
-    color: var(--cor-texto); /* Usa a cor clara do texto */
+    background-color: var(--cor-fundo-painel);
+    color: var(--cor-texto);
 }
 
 /* Minimal Chevron */
@@ -242,6 +242,72 @@ body {
   width: 100%;
   height: 100%;
 }
+
+/* =====================================================
+   Menu de Opções da Lupa/Zoom e Node
+   ====================================================*/
+
+.node-handle:hover {
+    fill: #4a90d9;
+    stroke: white;
+}
+
+#zoom-options {
+  position: absolute;
+  background: var(--cor-fundo-barra);
+  border: 1px solid var(--cor-borda-ui);
+  box-shadow: var(--sombra-padrao);
+  padding: 6px;
+  border-radius: var(--raio-borda);
+  flex-direction: column;
+  gap: 4px;
+}
+
+#zoom-options.hidden {
+  display: none;
+}
+
+#zoom-options:not(.hidden) {
+  display: flex;
+}
+
+#zoom-options button {
+  background-color: #4a90d9;
+  width: 36px;
+  height: 36px;
+  border: 1px solid transparent;
+  border-radius: var(--raio-borda);
+}
+
+#zoom-options button:hover {
+  border-color: var(--cor-destaque);
+}
+
+#zoom-options button.ativo {
+  background: rgba(0, 38, 255, 0.35);
+  border-color: var(--cor-destaque);
+}
+
+#zoom-indicator {
+  display: grid;
+  width: 120px;
+  height: 36px;
+  position: relative;
+  top: 8%;
+  right: 0%;
+  background: rgba(0, 0, 0, 0.7);
+  color: white;
+  padding: 6px 12px;
+  border-radius: 8px;
+  font-size: 14px;
+  font-family: sans-serif;
+  pointer-events: none;
+  overflow: hidden;
+}
+
+/* =========================================================
+   Tela Inicial e Menu de Opções
+   ========================================================= */
 
 .oculto {
   display: none !important;
@@ -312,6 +378,6 @@ body {
 }
 
 #btn-novo-doc:hover {
-  background-color: #3a7bc2; /* Tom levemente mais escuro */
+  background-color: #3a7bc2;
   transform: translateY(-2px);
 }

--- a/css/style.css
+++ b/css/style.css
@@ -203,6 +203,11 @@ body {
     border-color: #000;
 }
 
+.select-format option {
+    background-color: var(--cor-fundo-painel); /* Usa a cor escura do painel */
+    color: var(--cor-texto); /* Usa a cor clara do texto */
+}
+
 /* Minimal Chevron */
 .select-arrow {
     position: absolute;

--- a/css/style.css
+++ b/css/style.css
@@ -248,7 +248,7 @@ body {
    ====================================================*/
 
 .node-handle:hover {
-    fill: #4a90d9;
+    fill: #4a90d9; /* Inverte a cor ao passar o mouse */
     stroke: white;
 }
 

--- a/css/style.css
+++ b/css/style.css
@@ -209,6 +209,10 @@ body {
     display: inline-block;
 }
 
+.select-wrapper select {
+  width: 100%;
+}
+
 .select-format {
     appearance: none;
     -webkit-appearance: none;

--- a/index.html
+++ b/index.html
@@ -8,7 +8,31 @@
     </head>
 
     <body>
-        <div id="app">
+        <div id="tela-inicial">
+            <h1>Editor Vetorial 2026</h1>
+            <nav class="menu-opcoes">
+                <button id="btn-novo-doc" class="btn-menu">Criar novo documento</button>
+
+                <div class="grupo-opcao">
+                    <label for+"select-tamanho" class"propriedade-label">Tamanho da página:</label>
+                    <div class="select-wrapper">
+                        <select id="select-tamanho" class="select-format">
+                            <option value="livre" selected>Livre</option>
+                            <option value="a4">A4 (800x1131)</option>
+                            <option value="a3">A3 (1131x1600)</option>
+                        </select>
+                        <svg class="select-arrow" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                            <path d="M7 10l5 5 5-5z" />
+                        </svg>
+                    </div>
+                </div>
+
+                <button id="btn-abrir-arq" class="btn-menu">Abrir arquivo</button>
+                <button id="btn-modelos" class="btn-menu">Modelos (templates)</button>
+                <button id="btn-config" class="btn-menu">Configurações</button>
+            </nav>
+        </div>
+        <div id="app" class="oculto">
             <!-- Painel Superior: propriedades (cor de preenchimento, cor de borda, etc.) -->
             <header id="painel-propriedades">
                 <span class="propriedade-label">Preenchimento:</span>

--- a/js/core/StateManager.js
+++ b/js/core/StateManager.js
@@ -11,12 +11,13 @@
  *  - elementoSelecionado {SVGElement|null} - Elemento SVG atualmente selecionado.
  */
 
-/** @type {{ ferramentaAtual: import('../tools/ToolBase.js').ToolBase|null, corPreenchimento: string, corBorda: string, elementoSelecionado: SVGElement|null }} */
+/** @type {{ ferramentaAtual: import('../tools/ToolBase.js').ToolBase|null, corPreenchimento: string, corBorda: string, elementoSelecionado: SVGElement|null, interfaceAtual: string }} */
 export const estado = {
   ferramentaAtual: null,
   corPreenchimento: '#4a90d9',
   corBorda: '#1a1a2e',
   elementoSelecionado: null,
+  interfaceAtual: 'inicio', // Nova flag para sabermos onde o usuário está
 };
 
 let gerenciadorSelecaoVisual = null;
@@ -85,4 +86,9 @@ export function definirElementoSelecionado(elemento) {
   if (gerenciadorSelecaoVisual) {
     gerenciadorSelecaoVisual.desenhar(elemento);
   }
+}
+
+
+export function definirInterface(novaInterface) {
+  estado.interfaceAtual = novaInterface;
 }

--- a/js/core/UIManager.js
+++ b/js/core/UIManager.js
@@ -1,0 +1,88 @@
+import { definirInterface } from './StateManager.js';
+
+/**
+ * Inicializa os ouvintes de evento para a Tela Inicial
+ * @param {SVGSVGElement} svgCanvas - A referência ao canvas principal
+ */
+export function inicializarMenuInicial(svgCanvas) {
+    const telaInicial = document.getElementById('tela-inicial');
+    const telaEditor = document.getElementById('app');
+    
+    const btnNovoDoc = document.getElementById('btn-novo-doc');
+    const btnAbrirArq = document.getElementById('btn-abrir-arq');
+    const selectTamanho = document.getElementById('select-tamanho');
+
+    // Função central para transição de tela
+    function irParaEditor() {
+        telaInicial.classList.add('oculto');
+        telaEditor.classList.remove('oculto');
+        definirInterface('editor');
+    }
+
+    // 1. Lógica: Criar Novo Documento
+    btnNovoDoc.addEventListener('click', () => {
+        const tamanho = selectTamanho.value;
+        
+        // Aplica o tamanho selecionado alterando a ViewBox do SVG
+        if (tamanho === 'a4') {
+            svgCanvas.setAttribute('viewBox', '0 0 800 1131');
+            svgCanvas.style.backgroundColor = '#ffffff'; // Imita papel
+        } else if (tamanho === 'a3') {
+            svgCanvas.setAttribute('viewBox', '0 0 1131 1600');
+            svgCanvas.style.backgroundColor = '#ffffff';
+        } else {
+            // Documento Livre
+            svgCanvas.removeAttribute('viewBox');
+            svgCanvas.style.backgroundColor = 'var(--cor-fundo-canvas)';
+        }
+        
+        // Garante que começamos com um canvas limpo
+        svgCanvas.innerHTML = '';
+        irParaEditor();
+    });
+
+    // 2. Lógica: Abrir Arquivo (Lê um SVG do computador do usuário)
+    btnAbrirArq.addEventListener('click', () => {
+        // Criamos um input de arquivo invisível dinamicamente
+        const inputFalso = document.createElement('input');
+        inputFalso.type = 'file';
+        inputFalso.accept = '.svg';
+
+        inputFalso.addEventListener('change', (evento) => {
+            const arquivo = evento.target.files[0];
+            if (!arquivo) return;
+
+            const leitor = new FileReader();
+            leitor.onload = (e) => {
+                const conteudoSvg = e.target.result;
+                
+                // Transforma o texto do arquivo lido em Elementos DOM de verdade
+                const parser = new DOMParser();
+                const docSvg = parser.parseFromString(conteudoSvg, "image/svg+xml");
+                const svgImportado = docSvg.documentElement;
+
+                // Injeta o conteúdo no nosso canvas
+                svgCanvas.innerHTML = svgImportado.innerHTML;
+                
+                // Preserva o viewBox original do arquivo, se existir
+                if (svgImportado.hasAttribute('viewBox')) {
+                    svgCanvas.setAttribute('viewBox', svgImportado.getAttribute('viewBox'));
+                }
+                
+                irParaEditor();
+            };
+            leitor.readAsText(arquivo);
+        });
+
+        // Simula o clique do usuário para abrir a janela do Windows/Linux
+        inputFalso.click(); 
+    });
+
+    // 3. Stubs (Para as futuras issues)
+    document.getElementById('btn-modelos').addEventListener('click', () => {
+        alert('As opções de Template serão lançadas na versão 1.2!');
+    });
+    document.getElementById('btn-config').addEventListener('click', () => {
+        alert('As configurações avançadas serão implementadas em breve.');
+    });
+}

--- a/js/main.js
+++ b/js/main.js
@@ -13,9 +13,11 @@ import { RetanguloTool } from './tools/RetanguloTool.js';
 import { exportarDesenho } from './utils/exportHelpers.js';
 import { SelecaoTool } from './tools/SelecaoTool.js';
 import { Selecao } from './core/Selecao.js';
+import { inicializarMenuInicial } from './core/UIManager.js';
 
 // Referências aos elementos do DOM
 const svgCanvas = document.getElementById('canvas');
+inicializarMenuInicial(svgCanvas);
 const areaDesenho = document.getElementById('area-desenho');
 
 // Wrapper para sincronizar perfeitamente as coordenadas do #canvas com o #overlay-canvas


### PR DESCRIPTION
- Adiciona estrutura HTML e estilos CSS para a tela de início (#tela-inicial) isolada do editor.
- Cria a classe utilitária `.oculto` para alternância de interfaces (Single Page Application).
- Introduz o módulo `UIManager.js` para gerenciar eventos do menu sem sobrecarregar o `main.js`.
- Implementa a criação de novos documentos com predefinições de viewBox (A4, A3 e Livre).
- Adiciona suporte nativo para abertura de arquivos SVG locais utilizando a API FileReader.
- Atualiza `StateManager.js` adicionando a flag de controle `interfaceAtual`.
Resolves #46 