### PR TITLE
[Feat] Adicionando delete forma

### DIFF
--- a/js/core/StateManager.js
+++ b/js/core/StateManager.js
@@ -86,3 +86,17 @@ export function definirElementoSelecionado(elemento) {
     gerenciadorSelecaoVisual.desenhar(elemento);
   }
 }
+
+
+/**
+ * Remove o elemento atualmente selecionado do DOM e limpa a seleção.
+ */
+export function removerElementoSelecionado() {
+  if (estado.elementoSelecionado) {
+    // Remove o nó SVG diretamente do DOM
+    estado.elementoSelecionado.remove();
+    
+    // Limpa o estado global e remove a borda de seleção visual
+    definirElementoSelecionado(null);
+  }
+}

--- a/js/main.js
+++ b/js/main.js
@@ -13,6 +13,8 @@ import { RetanguloTool } from './tools/RetanguloTool.js';
 import { exportarDesenho } from './utils/exportHelpers.js';
 import { SelecaoTool } from './tools/SelecaoTool.js';
 import { Selecao } from './core/Selecao.js';
+import { LinhaTool } from './tools/LinhaTool.js';
+import { ElipseTool } from './tools/ElipseTool.js';
 
 // Referências aos elementos do DOM
 const svgCanvas = document.getElementById('canvas');
@@ -49,8 +51,9 @@ definirGerenciadorSelecao(selecaoVisual);
 const instanciasFerramentas = {
   selecao: new SelecaoTool(svgCanvas),
   retangulo: new RetanguloTool(svgCanvas),
+  linha: new LinhaTool(svgCanvas),    
+  elipse: new ElipseTool(svgCanvas),  
   "Conta-gotas": new ColorPickerTool(svgCanvas),
-  // Futuras ferramentas (elipse, linha, texto) entrarão aqui
 };
 
 const botoesFerramenta = document.querySelectorAll('.btn-ferramenta');

--- a/js/main.js
+++ b/js/main.js
@@ -2,97 +2,138 @@
  * main.js — Ponto de entrada da aplicação do Editor Vetorial.
  *
  * Responsabilidades:
- *  - Inicializar o estado global via StateManager
- *  - Registrar os event listeners globais no elemento SVG (#canvas)
- *  - Conectar os botões da barra de ferramentas ao StateManager
+ * - Inicializar o estado global via StateManager
+ * - Registrar event listeners globais no elemento SVG (#canvas)
+ * - Conectar os controles da interface ao estado da aplicação
  */
 
-import { estado, definirFerramenta, definirCorPreenchimento, definirCorBorda, definirGerenciadorSelecao } from './core/StateManager.js';
+import { 
+  estado, 
+  definirFerramenta, 
+  definirCorPreenchimento, 
+  definirCorBorda, 
+  definirGerenciadorSelecao,
+  removerElementoSelecionado 
+} from './core/StateManager.js';
+
 import { ColorPickerTool } from './tools/ColorPickerTool.js';
 import { RetanguloTool } from './tools/RetanguloTool.js';
-import { exportarDesenho } from './utils/exportHelpers.js';
-import { SelecaoTool } from './tools/SelecaoTool.js';
-import { Selecao } from './core/Selecao.js';
 import { LinhaTool } from './tools/LinhaTool.js';
 import { ElipseTool } from './tools/ElipseTool.js';
+import { SelecaoTool } from './tools/SelecaoTool.js';
 
-// Referências aos elementos do DOM
+import { exportarDesenho } from './utils/exportHelpers.js';
+import { Selecao } from './core/Selecao.js';
+
+/* ============================================================================
+ * REFERÊNCIAS AO DOM
+ * ========================================================================== */
+
 const svgCanvas = document.getElementById('canvas');
 const areaDesenho = document.getElementById('area-desenho');
 
-// Wrapper para sincronizar perfeitamente as coordenadas do #canvas com o #overlay-canvas
-const canvasContainer = document.createElement('div');
-canvasContainer.style.position = 'relative';
-canvasContainer.style.width = '100%';
-canvasContainer.style.height = '100%';
-
-// Encapsulando o svg original
-svgCanvas.parentNode.insertBefore(canvasContainer, svgCanvas);
-canvasContainer.appendChild(svgCanvas);
-
-// 1. Camada de Interação: instanciar o novo SVG de overlay para seleções
-const overlayCanvas = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
-overlayCanvas.setAttribute('id', 'overlay-canvas');
-overlayCanvas.setAttribute('width', '100%');
-overlayCanvas.setAttribute('height', '100%');
-overlayCanvas.style.position = 'absolute';
-overlayCanvas.style.top = '0';
-overlayCanvas.style.left = '0';
-overlayCanvas.style.pointerEvents = 'none'; // Coordenado com o principal
-canvasContainer.appendChild(overlayCanvas);
-
-// Inicializar a classe de seleção
-const selecaoVisual = new Selecao(overlayCanvas);
-definirGerenciadorSelecao(selecaoVisual);
-
-
-
-// Instâncias das ferramentas disponíveis
-const instanciasFerramentas = {
-  selecao: new SelecaoTool(svgCanvas),
-  retangulo: new RetanguloTool(svgCanvas),
-  linha: new LinhaTool(svgCanvas),    
-  elipse: new ElipseTool(svgCanvas),  
-  "Conta-gotas": new ColorPickerTool(svgCanvas),
-};
-
 const botoesFerramenta = document.querySelectorAll('.btn-ferramenta');
-const inputCorPreenchimento = (
-  document.getElementById('cor-preenchimento')
-);
-const inputCorBorda = (
-  document.getElementById('cor-borda')
-);
+const inputCorPreenchimento = document.getElementById('cor-preenchimento');
+const inputCorBorda = document.getElementById('cor-borda');
 
 const nomeFerramenta = document.getElementById('nome-ferramenta');
 const btnExportar = document.getElementById('btn-exportar');
 const exportFormat = document.getElementById('export-format');
 
+/* ============================================================================
+ * CONFIGURAÇÃO DO CANVAS (WRAPPER + OVERLAY)
+ * ========================================================================== */
+
+/**
+ * Cria um container para sincronizar coordenadas entre o canvas principal
+ * e o canvas de overlay (usado para seleção).
+ */
+const canvasContainer = document.createElement('div');
+canvasContainer.style.position = 'relative';
+canvasContainer.style.width = '100%';
+canvasContainer.style.height = '100%';
+
+/**
+ * Encapsula o SVG principal dentro do container.
+ */
+svgCanvas.parentNode.insertBefore(canvasContainer, svgCanvas);
+canvasContainer.appendChild(svgCanvas);
+
+/**
+ * Cria o SVG de overlay responsável por elementos visuais de interação
+ * (ex: seleção), sem interferir nos eventos do canvas principal.
+ */
+const overlayCanvas = document.createElementNS(
+  'http://www.w3.org/2000/svg',
+  'svg'
+);
+
+overlayCanvas.setAttribute('id', 'overlay-canvas');
+overlayCanvas.setAttribute('width', '100%');
+overlayCanvas.setAttribute('height', '100%');
+
+overlayCanvas.style.position = 'absolute';
+overlayCanvas.style.top = '0';
+overlayCanvas.style.left = '0';
+overlayCanvas.style.pointerEvents = 'none';
+
+canvasContainer.appendChild(overlayCanvas);
+
+/* ============================================================================
+ * INICIALIZAÇÃO DO SISTEMA DE SELEÇÃO
+ * ========================================================================== */
+
+/**
+ * Instancia o gerenciador de seleção visual e registra no estado global.
+ */
+const selecaoVisual = new Selecao(overlayCanvas);
+definirGerenciadorSelecao(selecaoVisual);
+
+/* ============================================================================
+ * INSTÂNCIAS DAS FERRAMENTAS
+ * ========================================================================== */
+
+/**
+ * Mapeamento das ferramentas disponíveis na aplicação.
+ */
+const instanciasFerramentas = {
+  selecao: new SelecaoTool(svgCanvas),
+  retangulo: new RetanguloTool(svgCanvas),
+  linha: new LinhaTool(svgCanvas),
+  elipse: new ElipseTool(svgCanvas),
+  'Conta-gotas': new ColorPickerTool(svgCanvas),
+};
+
+/* ============================================================================
+ * FUNÇÕES AUXILIARES DE UI
+ * ========================================================================== */
+
 /**
  * Atualiza o estado visual dos botões da barra lateral,
  * destacando apenas o botão da ferramenta ativa.
  *
- * @param {string} nomeDaFerramenta - Identificador da ferramenta ativa.
+ * @param {string} nomeDaFerramenta - Identificador da ferramenta ativa
  */
 function atualizarBotaoAtivo(nomeDaFerramenta) {
   botoesFerramenta.forEach((btn) => {
-    if (btn.getAttribute('data-ferramenta') === nomeDaFerramenta) {
-      btn.classList.add('ativo');
-    } else {
-      btn.classList.remove('ativo');
-    }
+    const ferramenta = btn.getAttribute('data-ferramenta');
+
+    btn.classList.toggle('ativo', ferramenta === nomeDaFerramenta);
   });
+
   nomeFerramenta.textContent = nomeDaFerramenta || 'Nenhuma';
 }
 
-// --- Registro dos Event Listeners ---
+/* ============================================================================
+ * REGISTRO DE EVENT LISTENERS
+ * ========================================================================== */
 
-// Seleciona a ferramenta ao clicar nos botões da barra lateral
+/**
+ * Seleção de ferramentas via interface (botões).
+ */
 botoesFerramenta.forEach((btn) => {
   btn.addEventListener('click', () => {
     const ferramentaId = btn.getAttribute('data-ferramenta');
-
-    // Obtém a instância da ferramenta atual correspondente (se implementada)
     const ferramentaInstancia = instanciasFerramentas[ferramentaId] || null;
 
     definirFerramenta(ferramentaInstancia);
@@ -100,41 +141,60 @@ botoesFerramenta.forEach((btn) => {
   });
 });
 
-// Atualiza a cor de preenchimento no estado global
-inputCorPreenchimento.addEventListener('input', (evento) => {
+/**
+ * Atualização das cores no estado global.
+ */
+inputCorPreenchimento.addEventListener('input', () => {
   definirCorPreenchimento(inputCorPreenchimento.value);
 });
 
-// Atualiza a cor da borda no estado global
-inputCorBorda.addEventListener('input', (evento) => {
+inputCorBorda.addEventListener('input', () => {
   definirCorBorda(inputCorBorda.value);
 });
 
-// Event listeners globais do SVG (delegados para a ferramenta ativa)
+/**
+ * Delegação de eventos do mouse para a ferramenta ativa.
+ */
 svgCanvas.addEventListener('mousedown', (evento) => {
-  if (estado.ferramentaAtual) {
-    estado.ferramentaAtual.onMouseDown(evento);
-  }
+  estado.ferramentaAtual?.onMouseDown(evento);
 });
 
 svgCanvas.addEventListener('mousemove', (evento) => {
-  if (estado.ferramentaAtual) {
-    estado.ferramentaAtual.onMouseMove(evento);
-  }
+  estado.ferramentaAtual?.onMouseMove(evento);
 });
 
 svgCanvas.addEventListener('mouseup', (evento) => {
-  if (estado.ferramentaAtual) {
-    estado.ferramentaAtual.onMouseUp(evento);
-  }
+  estado.ferramentaAtual?.onMouseUp(evento);
 });
 
-// Inicializa os valores dos inputs com os valores padrão do estado
+/**
+ * Inicializa inputs com valores do estado global.
+ */
 inputCorPreenchimento.value = estado.corPreenchimento;
 inputCorBorda.value = estado.corBorda;
 
-// Exportar / Salvar desenho
+/**
+ * Exportação do desenho.
+ */
 btnExportar.addEventListener('click', () => {
   const formato = exportFormat.value || 'png';
   exportarDesenho(svgCanvas, formato);
+});
+
+/* ============================================================================
+ * ATALHOS DE TECLADO
+ * ========================================================================== */
+
+/**
+ * Remove elemento selecionado ao pressionar Delete/Backspace,
+ * exceto quando o foco está em campos de entrada.
+ */
+window.addEventListener('keydown', (evento) => {
+  const tagAtiva = evento.target.tagName.toLowerCase();
+
+  if (tagAtiva === 'input' || tagAtiva === 'textarea') return;
+
+  if (evento.key === 'Delete' || evento.key === 'Backspace') {
+    removerElementoSelecionado();
+  }
 });

--- a/js/tools/ElipseTool.js
+++ b/js/tools/ElipseTool.js
@@ -1,0 +1,75 @@
+import { ToolBase } from './ToolBase.js';
+import { criarElementoSVG, obterCoordenadaSVG } from '../utils/svgHelpers.js';
+import { estado } from '../core/StateManager.js';
+
+/**
+ * ElipseTool
+ * 
+ * Ferramenta responsável por desenhar elipses no canvas SVG.
+ */
+export class ElipseTool extends ToolBase {
+  constructor(svgCanvas) {
+    super();
+    this.svgCanvas = svgCanvas;
+    this.isDrawing = false;
+    this.startX = 0;
+    this.startY = 0;
+    this.elipseElement = null;
+  }
+
+  onMouseDown(evento) {
+    this.isDrawing = true;
+
+    const pt = obterCoordenadaSVG(evento, this.svgCanvas);
+    this.startX = pt.x;
+    this.startY = pt.y;
+
+    // Cria o elemento <ellipse>. 
+    // Inicialmente com raios zero no ponto de clique.
+    this.elipseElement = criarElementoSVG('ellipse', {
+      cx: this.startX,
+      cy: this.startY,
+      rx: 0,
+      ry: 0,
+      fill: estado.corPreenchimento,
+      stroke: estado.corBorda,
+      'stroke-width': 2
+    });
+
+    this.svgCanvas.appendChild(this.elipseElement);
+  }
+
+  onMouseMove(evento) {
+    if (!this.isDrawing || !this.elipseElement) return;
+
+    const pt = obterCoordenadaSVG(evento, this.svgCanvas);
+
+    // Cálculos matemáticos para a elipse
+    // O raio é metade da distância absoluta entre o início e o cursor
+    const rx = Math.abs(pt.x - this.startX) / 2;
+    const ry = Math.abs(pt.y - this.startY) / 2;
+
+    // O centro (cx, cy) deve ser o ponto médio entre o clique inicial e o cursor
+    const cx = (this.startX + pt.x) / 2;
+    const cy = (this.startY + pt.y) / 2;
+
+    this.elipseElement.setAttribute('cx', cx);
+    this.elipseElement.setAttribute('cy', cy);
+    this.elipseElement.setAttribute('rx', rx);
+    this.elipseElement.setAttribute('ry', ry);
+  }
+
+  onMouseUp(evento) {
+    this.isDrawing = false;
+    this.elipseElement = null;
+    // Integração futura com HistoryManager aqui
+  }
+
+  onDesativar() {
+    if (this.isDrawing && this.elipseElement) {
+      this.elipseElement.remove();
+      this.isDrawing = false;
+      this.elipseElement = null;
+    }
+  }
+}

--- a/js/tools/LinhaTool.js
+++ b/js/tools/LinhaTool.js
@@ -1,0 +1,36 @@
+import { ToolBase } from './ToolBase.js';
+import { criarElementoSVG, obterCoordenadaSVG } from '../utils/svgHelpers.js';
+import { estado } from '../core/StateManager.js';
+
+export class LinhaTool extends ToolBase {
+  constructor(svgCanvas) {
+    super();
+    this.svgCanvas = svgCanvas;
+    this.isDrawing = false;
+    this.lineElement = null;
+  }
+
+  onMouseDown(evento) {
+    this.isDrawing = true;
+    const pt = obterCoordenadaSVG(evento, this.svgCanvas);
+    this.lineElement = criarElementoSVG('line', {
+      x1: pt.x, y1: pt.y,
+      x2: pt.x, y2: pt.y,
+      stroke: estado.corBorda,
+      'stroke-width': 2
+    });
+    this.svgCanvas.appendChild(this.lineElement);
+  }
+
+  onMouseMove(evento) {
+    if (!this.isDrawing || !this.lineElement) return;
+    const pt = obterCoordenadaSVG(evento, this.svgCanvas);
+    this.lineElement.setAttribute('x2', pt.x);
+    this.lineElement.setAttribute('y2', pt.y);
+  }
+
+  onMouseUp() {
+    this.isDrawing = false;
+    this.lineElement = null;
+  }
+}


### PR DESCRIPTION
- Cria a função `removerElementoSelecionado` no StateManager para remover o nó do DOM e resetar o estado visual.
- Adiciona um listener global de 'keydown' no main.js interceptando as teclas Delete e Backspace.
- Implementa regra de exceção para ignorar o atalho se o usuário estiver focando em campos de input.
- também deixei os comentários do main mais separados por funcionalidade.