### PR TITLE
51 melhorar ferramenta de seleção

### DIFF
--- a/js/core/Selecao.js
+++ b/js/core/Selecao.js
@@ -1,4 +1,4 @@
-import { criarElementoSVG } from '../utils/svgHelpers.js';
+import { criarElementoSVG, converterCoordenadaClienteParaSVG } from '../utils/svgHelpers.js';
 
 export class Selecao {
   constructor(overlaySvg) {
@@ -6,17 +6,30 @@ export class Selecao {
     this.bordaSelecao = null;
   }
 
+  /**
+   * Desenha a borda de seleção ao redor do elemento.
+   * @param {SVGElement} elementoSelecionado 
+   */
   desenhar(elementoSelecionado) {
     this.limpar();
 
     if (!elementoSelecionado) return;
 
-    const bbox = elementoSelecionado.getBBox();
+    // Obtém o retângulo delimitador no sistema de coordenadas do viewport (tela)
+    const rect = elementoSelecionado.getBoundingClientRect();
+    
+    // Converte os pontos do viewport para o sistema de coordenadas interno do SVG de overlay
+    const ptSuperiorEsquerda = converterCoordenadaClienteParaSVG(rect.left, rect.top, this.overlaySvg);
+    const ptInferiorDireita = converterCoordenadaClienteParaSVG(rect.right, rect.bottom, this.overlaySvg);
+
+    const largura = ptInferiorDireita.x - ptSuperiorEsquerda.x;
+    const altura = ptInferiorDireita.y - ptSuperiorEsquerda.y;
+
     this.bordaSelecao = criarElementoSVG('rect', {
-      x: bbox.x - 2,
-      y: bbox.y - 2,
-      width: bbox.width + 4,
-      height: bbox.height + 4,
+      x: ptSuperiorEsquerda.x - 2,
+      y: ptSuperiorEsquerda.y - 2,
+      width: largura + 4,
+      height: altura + 4,
       fill: 'none',
       stroke: "blue",
       'stroke-width': 1.5,
@@ -26,11 +39,23 @@ export class Selecao {
     this.overlaySvg.appendChild(this.bordaSelecao);
   }
 
+  /**
+   * Atualiza a posição e dimensões da borda de seleção.
+   * @param {SVGElement} elementoSelecionado 
+   */
   atualizarPosicao(elementoSelecionado) {
     if (this.bordaSelecao && elementoSelecionado) {
-      const bbox = elementoSelecionado.getBBox();
-      this.bordaSelecao.setAttribute('x', String(bbox.x - 2));
-      this.bordaSelecao.setAttribute('y', String(bbox.y - 2));
+      const rect = elementoSelecionado.getBoundingClientRect();
+      const ptSuperiorEsquerda = converterCoordenadaClienteParaSVG(rect.left, rect.top, this.overlaySvg);
+      const ptInferiorDireita = converterCoordenadaClienteParaSVG(rect.right, rect.bottom, this.overlaySvg);
+
+      const largura = ptInferiorDireita.x - ptSuperiorEsquerda.x;
+      const altura = ptInferiorDireita.y - ptSuperiorEsquerda.y;
+
+      this.bordaSelecao.setAttribute('x', String(ptSuperiorEsquerda.x - 2));
+      this.bordaSelecao.setAttribute('y', String(ptSuperiorEsquerda.y - 2));
+      this.bordaSelecao.setAttribute('width', String(largura + 4));
+      this.bordaSelecao.setAttribute('height', String(altura + 4));
     }
   }
 

--- a/js/core/Selecao.js
+++ b/js/core/Selecao.js
@@ -7,29 +7,21 @@ export class Selecao {
   }
 
   /**
-   * Desenha a borda de seleção ao redor do elemento.
-   * @param {SVGElement} elementoSelecionado 
+   * Desenha a borda de seleção ao redor do conjunto de elementos.
+   * @param {SVGElement[]} elementosSelecionados 
    */
-  desenhar(elementoSelecionado) {
+  desenhar(elementosSelecionados) {
     this.limpar();
 
-    if (!elementoSelecionado) return;
+    if (!elementosSelecionados || elementosSelecionados.length === 0) return;
 
-    // Obtém o retângulo delimitador no sistema de coordenadas do viewport (tela)
-    const rect = elementoSelecionado.getBoundingClientRect();
-    
-    // Converte os pontos do viewport para o sistema de coordenadas interno do SVG de overlay
-    const ptSuperiorEsquerda = converterCoordenadaClienteParaSVG(rect.left, rect.top, this.overlaySvg);
-    const ptInferiorDireita = converterCoordenadaClienteParaSVG(rect.right, rect.bottom, this.overlaySvg);
-
-    const largura = ptInferiorDireita.x - ptSuperiorEsquerda.x;
-    const altura = ptInferiorDireita.y - ptSuperiorEsquerda.y;
+    const bounds = this._calcularBoundsUnificados(elementosSelecionados);
 
     this.bordaSelecao = criarElementoSVG('rect', {
-      x: ptSuperiorEsquerda.x - 2,
-      y: ptSuperiorEsquerda.y - 2,
-      width: largura + 4,
-      height: altura + 4,
+      x: bounds.minX - 2,
+      y: bounds.minY - 2,
+      width: bounds.maxX - bounds.minX + 4,
+      height: bounds.maxY - bounds.minY + 4,
       fill: 'none',
       stroke: "blue",
       'stroke-width': 1.5,
@@ -40,23 +32,39 @@ export class Selecao {
   }
 
   /**
-   * Atualiza a posição e dimensões da borda de seleção.
-   * @param {SVGElement} elementoSelecionado 
+   * Atualiza a posição e dimensões da borda de seleção para múltiplos elementos.
+   * @param {SVGElement[]} elementosSelecionados 
    */
-  atualizarPosicao(elementoSelecionado) {
-    if (this.bordaSelecao && elementoSelecionado) {
-      const rect = elementoSelecionado.getBoundingClientRect();
-      const ptSuperiorEsquerda = converterCoordenadaClienteParaSVG(rect.left, rect.top, this.overlaySvg);
-      const ptInferiorDireita = converterCoordenadaClienteParaSVG(rect.right, rect.bottom, this.overlaySvg);
+  atualizarPosicao(elementosSelecionados) {
+    if (this.bordaSelecao && elementosSelecionados && elementosSelecionados.length > 0) {
+      const bounds = this._calcularBoundsUnificados(elementosSelecionados);
 
-      const largura = ptInferiorDireita.x - ptSuperiorEsquerda.x;
-      const altura = ptInferiorDireita.y - ptSuperiorEsquerda.y;
-
-      this.bordaSelecao.setAttribute('x', String(ptSuperiorEsquerda.x - 2));
-      this.bordaSelecao.setAttribute('y', String(ptSuperiorEsquerda.y - 2));
-      this.bordaSelecao.setAttribute('width', String(largura + 4));
-      this.bordaSelecao.setAttribute('height', String(altura + 4));
+      this.bordaSelecao.setAttribute('x', String(bounds.minX - 2));
+      this.bordaSelecao.setAttribute('y', String(bounds.minY - 2));
+      this.bordaSelecao.setAttribute('width', String(bounds.maxX - bounds.minX + 4));
+      this.bordaSelecao.setAttribute('height', String(bounds.maxY - bounds.minY + 4));
     }
+  }
+
+  /**
+   * Calcula os limites (min/max) de um conjunto de elementos no espaço do SVG de overlay.
+   * @private
+   */
+  _calcularBoundsUnificados(elementos) {
+    let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
+
+    elementos.forEach(el => {
+      const rect = el.getBoundingClientRect();
+      const pt1 = converterCoordenadaClienteParaSVG(rect.left, rect.top, this.overlaySvg);
+      const pt2 = converterCoordenadaClienteParaSVG(rect.right, rect.bottom, this.overlaySvg);
+
+      minX = Math.min(minX, pt1.x, pt2.x);
+      minY = Math.min(minY, pt1.y, pt2.y);
+      maxX = Math.max(maxX, pt1.x, pt2.x);
+      maxY = Math.max(maxY, pt1.y, pt2.y);
+    });
+
+    return { minX, minY, maxX, maxY };
   }
 
   limpar() {

--- a/js/core/StateManager.js
+++ b/js/core/StateManager.js
@@ -11,12 +11,12 @@
  *  - elementoSelecionado {SVGElement|null} - Elemento SVG atualmente selecionado.
  */
 
-/** @type {{ ferramentaAtual: import('../tools/ToolBase.js').ToolBase|null, corPreenchimento: string, corBorda: string, elementoSelecionado: SVGElement|null }} */
+/** @type {{ ferramentaAtual: import('../tools/ToolBase.js').ToolBase|null, corPreenchimento: string, corBorda: string, elementosSelecionados: SVGElement[] }} */
 export const estado = {
   ferramentaAtual: null,
   corPreenchimento: '#4a90d9',
   corBorda: '#1a1a2e',
-  elementoSelecionado: null,
+  elementosSelecionados: [],
 };
 
 let gerenciadorSelecaoVisual = null;
@@ -26,8 +26,8 @@ export function definirGerenciadorSelecao(selecao) {
 }
 
 export function atualizarPosicaoSelecaoVisual() {
-  if (gerenciadorSelecaoVisual && estado.elementoSelecionado) {
-    gerenciadorSelecaoVisual.atualizarPosicao(estado.elementoSelecionado);
+  if (gerenciadorSelecaoVisual && estado.elementosSelecionados.length > 0) {
+    gerenciadorSelecaoVisual.atualizarPosicao(estado.elementosSelecionados);
   }
 }
 
@@ -38,8 +38,6 @@ export function atualizarPosicaoSelecaoVisual() {
  *
  * @param {import('../tools/ToolBase.js').ToolBase|string|null} ferramenta
  *   Instância de uma ferramenta (ToolBase) ou string identificadora.
- *   Futuras implementações de ferramentas deverão passar a instância;
- *   por ora, aceita string para permitir a seleção via botões da UI.
  */
 export function definirFerramenta(ferramenta) {
   const anterior = estado.ferramentaAtual;
@@ -76,13 +74,54 @@ export function definirCorBorda(cor) {
 }
 
 /**
- * Define o elemento SVG atualmente selecionado.
+ * Define os elementos SVG atualmente selecionados.
  *
- * @param {SVGElement|null} elemento - Elemento SVG selecionado ou null para limpar a seleção.
+ * @param {SVGElement|SVGElement[]|null} elementos - Elemento(s) SVG selecionado(s) ou null para limpar.
+ */
+export function definirElementosSelecionados(elementos) {
+  if (!elementos) {
+    estado.elementosSelecionados = [];
+  } else if (Array.isArray(elementos)) {
+    estado.elementosSelecionados = elementos;
+  } else {
+    estado.elementosSelecionados = [elementos];
+  }
+
+  if (gerenciadorSelecaoVisual) {
+    gerenciadorSelecaoVisual.desenhar(estado.elementosSelecionados);
+  }
+}
+
+/**
+ * Alias para compatibilidade ou seleção única.
+ * @deprecated Use definirElementosSelecionados
  */
 export function definirElementoSelecionado(elemento) {
-  estado.elementoSelecionado = elemento;
+  definirElementosSelecionados(elemento);
+}
+
+/**
+ * Adiciona um elemento à seleção atual.
+ *
+ * @param {SVGElement} elemento
+ */
+export function adicionarElementoSelecao(elemento) {
+  if (!estado.elementosSelecionados.includes(elemento)) {
+    estado.elementosSelecionados.push(elemento);
+    if (gerenciadorSelecaoVisual) {
+      gerenciadorSelecaoVisual.desenhar(estado.elementosSelecionados);
+    }
+  }
+}
+
+/**
+ * Remove um elemento da seleção atual.
+ *
+ * @param {SVGElement} elemento
+ */
+export function removerElementoSelecao(elemento) {
+  estado.elementosSelecionados = estado.elementosSelecionados.filter(el => el !== elemento);
   if (gerenciadorSelecaoVisual) {
-    gerenciadorSelecaoVisual.desenhar(elemento);
+    gerenciadorSelecaoVisual.desenhar(estado.elementosSelecionados);
   }
 }

--- a/js/tools/SelecaoTool.js
+++ b/js/tools/SelecaoTool.js
@@ -1,6 +1,12 @@
 import { ToolBase } from './ToolBase.js';
 import { obterCoordenadaSVG } from '../utils/svgHelpers.js';
-import { definirElementoSelecionado, atualizarPosicaoSelecaoVisual } from '../core/StateManager.js';
+import { 
+  estado, 
+  definirElementosSelecionados, 
+  adicionarElementoSelecao, 
+  removerElementoSelecao, 
+  atualizarPosicaoSelecaoVisual 
+} from '../core/StateManager.js';
 
 /**
  * Ferramenta de Seleção
@@ -10,74 +16,82 @@ export class SelecaoTool extends ToolBase {
     super();
     this.svgCanvas = svgCanvas;
 
-    this.elementoSelecionado = null;
-
     this.isDragging = false;
-    this.offsetX = 0;
-    this.offsetY = 0;
+    this.offsets = []; // Armazena offsets para múltiplos elementos
   }
 
   onMouseDown(evento) {
     const pt = obterCoordenadaSVG(evento, this.svgCanvas);
     const target = evento.target;
+    const isShift = evento.shiftKey;
 
-    // Limpa a seleção anterior
-    this.limparSelecao();
-
-    const allowedTags = ['rect', 'text', 'image', 'circle', 'ellipse'];
+    const allowedTags = ['rect', 'text', 'image', 'circle', 'ellipse', 'g', 'path', 'line'];
     const tag = target.tagName ? target.tagName.toLowerCase() : '';
 
-    // Se o clique não foi no canvas vazio e for um elemento permitido
-    if (
-      target !== this.svgCanvas &&
-      target.parentNode === this.svgCanvas &&
-      allowedTags.includes(tag)
-    ) {
-      this.elementoSelecionado = target;
+    // Verifica se o clique foi em um elemento válido dentro do canvas
+    const elementoAlvo = this._buscarElementoValido(target, allowedTags);
 
-      // Chama a função definindo o elemento selecionado no gerenciador de estado, o que atualiza a camada visual de seleção.
-      definirElementoSelecionado(target);
-
-      // Inicia a Movimentação
-      this.isDragging = true;
-
-      // Movimentação: Cálculo do offset para que o arraste seja suave
-      let elX = 0, elY = 0;
-
-      if (tag === 'rect' || tag === 'text' || tag === 'image') {
-        elX = parseFloat(target.getAttribute('x') || 0);
-        elY = parseFloat(target.getAttribute('y') || 0);
-      } else if (tag === 'circle' || tag === 'ellipse') {
-        elX = parseFloat(target.getAttribute('cx') || 0);
-        elY = parseFloat(target.getAttribute('cy') || 0);
+    if (elementoAlvo) {
+      if (isShift) {
+        // Alterna seleção com Shift
+        if (estado.elementosSelecionados.includes(elementoAlvo)) {
+          removerElementoSelecao(elementoAlvo);
+        } else {
+          adicionarElementoSelecao(elementoAlvo);
+        }
+      } else {
+        // Seleção única: limpa se clicar em algo novo, mantém se clicar em um já selecionado (para drag)
+        if (!estado.elementosSelecionados.includes(elementoAlvo)) {
+          definirElementosSelecionados([elementoAlvo]);
+        }
       }
 
-      this.offsetX = pt.x - elX;
-      this.offsetY = pt.y - elY;
+      // Prepara o arraste se houver seleção
+      if (estado.elementosSelecionados.length > 0) {
+        this.isDragging = true;
+        this._calcularOffsets(pt);
+      }
+    } else {
+      // Clique no vazio limpa a seleção se não estiver usando Shift
+      if (!isShift) {
+        this.limparSelecao();
+      }
     }
   }
 
   onMouseMove(evento) {
-    if (!this.isDragging || !this.elementoSelecionado) return;
+    if (!this.isDragging || estado.elementosSelecionados.length === 0) return;
 
     const pt = obterCoordenadaSVG(evento, this.svgCanvas);
 
-    // Calcula as novas coordenadas baseX e baseY, usando o offset
-    const novoX = pt.x - this.offsetX;
-    const novoY = pt.y - this.offsetY;
+    estado.elementosSelecionados.forEach((el, index) => {
+      const offset = this.offsets[index];
+      if (!offset) return;
 
-    const tag = this.elementoSelecionado.tagName.toLowerCase();
+      const novoX = pt.x - offset.x;
+      const novoY = pt.y - offset.y;
 
-    // Atualiza as propriedades dependendo da forma
-    if (tag === 'rect' || tag === 'text' || tag === 'image') {
-      this.elementoSelecionado.setAttribute('x', novoX);
-      this.elementoSelecionado.setAttribute('y', novoY);
-    } else if (tag === 'circle' || tag === 'ellipse') {
-      this.elementoSelecionado.setAttribute('cx', novoX);
-      this.elementoSelecionado.setAttribute('cy', novoY);
-    }
+      const tag = el.tagName.toLowerCase();
 
-    // Atualiza a posição da borda de seleção
+      // Atualiza coordenadas baseado no tipo de elemento
+      if (tag === 'rect' || tag === 'text' || tag === 'image') {
+        el.setAttribute('x', String(novoX));
+        el.setAttribute('y', String(novoY));
+      } else if (tag === 'circle' || tag === 'ellipse') {
+        el.setAttribute('cx', String(novoX));
+        el.setAttribute('cy', String(novoY));
+      } else if (tag === 'line') {
+          // Exemplo simplificado para linha (move mantendo comprimento)
+          const dx = novoX - parseFloat(el.getAttribute('x1') || 0);
+          const dy = novoY - parseFloat(el.getAttribute('y1') || 0);
+          el.setAttribute('x1', String(novoX));
+          el.setAttribute('y1', String(novoY));
+          el.setAttribute('x2', String(parseFloat(el.getAttribute('x2') || 0) + dx));
+          el.setAttribute('y2', String(parseFloat(el.getAttribute('y2') || 0) + dy));
+      }
+      // Grupos (g) e Paths seriam movidos via transform (não implementado aqui para simplicidade)
+    });
+
     atualizarPosicaoSelecaoVisual();
   }
 
@@ -90,8 +104,50 @@ export class SelecaoTool extends ToolBase {
   }
 
   limparSelecao() {
-    this.elementoSelecionado = null;
     this.isDragging = false;
-    definirElementoSelecionado(null);
+    this.offsets = [];
+    definirElementosSelecionados([]);
+  }
+
+  /**
+   * Busca o elemento selecionável mais próximo na hierarquia.
+   * @private
+   */
+  _buscarElementoValido(target, allowedTags) {
+    if (target === this.svgCanvas) return null;
+
+    let atual = target;
+    while (atual && atual !== this.svgCanvas) {
+      const tag = atual.tagName.toLowerCase();
+      if (allowedTags.includes(tag)) {
+        return atual;
+      }
+      atual = atual.parentNode;
+    }
+    return null;
+  }
+
+  /**
+   * Calcula a distância entre o clique e a posição de cada elemento selecionado.
+   * @private
+   */
+  _calcularOffsets(pontoMouse) {
+    this.offsets = estado.elementosSelecionados.map(el => {
+      const tag = el.tagName.toLowerCase();
+      let elX = 0, elY = 0;
+
+      if (tag === 'rect' || tag === 'text' || tag === 'image') {
+        elX = parseFloat(el.getAttribute('x') || 0);
+        elY = parseFloat(el.getAttribute('y') || 0);
+      } else if (tag === 'circle' || tag === 'ellipse') {
+        elX = parseFloat(el.getAttribute('cx') || 0);
+        elY = parseFloat(el.getAttribute('cy') || 0);
+      } else if (tag === 'line') {
+        elX = parseFloat(el.getAttribute('x1') || 0);
+        elY = parseFloat(el.getAttribute('y1') || 0);
+      }
+
+      return { x: pontoMouse.x - elX, y: pontoMouse.y - elY };
+    });
   }
 }

--- a/js/utils/svgHelpers.js
+++ b/js/utils/svgHelpers.js
@@ -41,16 +41,28 @@ export function criarElementoSVG(tag, atributos = {}) {
  * @returns {{ x: number, y: number }} Coordenadas no espaço do SVG.
  */
 export function obterCoordenadaSVG(evento, svgElement) {
+  return converterCoordenadaClienteParaSVG(evento.clientX, evento.clientY, svgElement);
+}
+
+/**
+ * Converte coordenadas de tela (viewport) para coordenadas locais do SVG.
+ *
+ * @param {number} x - Coordenada X no viewport.
+ * @param {number} y - Coordenada Y no viewport.
+ * @param {SVGSVGElement} svgElement - O elemento SVG de referência.
+ * @returns {{ x: number, y: number }} Coordenadas no espaço do SVG.
+ */
+export function converterCoordenadaClienteParaSVG(x, y, svgElement) {
   const ponto = svgElement.createSVGPoint();
-  ponto.x = evento.clientX;
-  ponto.y = evento.clientY;
+  ponto.x = x;
+  ponto.y = y;
 
   const matrizCTM = svgElement.getScreenCTM();
 
   if (!matrizCTM) {
     // Fallback para coordenadas do cliente caso a matriz não esteja disponível
     const rect = svgElement.getBoundingClientRect();
-    return { x: evento.clientX - rect.left, y: evento.clientY - rect.top };
+    return { x: x - rect.left, y: y - rect.top };
   }
 
   const matrizInversa = matrizCTM.inverse();


### PR DESCRIPTION
Troca do uso de `.getBBox()` por `.getBoundingClientRect()`, garantindo que a borda de destaque englobe corretamente as dimensões reais renderizadas (incluindo espessura de bordas e transformações). Para isso, foi implementado um novo utilitário em `svgHelpers.js` que converte as coordenadas do viewport de volta para o espaço do SVG, permitindo que o realce visual acompanhe fielmente o elemento selecionado independentemente de escalas ou deslocamentos.

E também foi implementado o suporte à múltipla seleção de elementos através do uso da tecla `Shift`, permitindo que diversos objetos sejam manipulados simultaneamente. Além disso, a lógica de arraste foi reformulada para suportar o movimento sincronizado de grupos de elementos e a interface visual foi atualizada para exibir um quadro delimitador unificado ao redor de toda a seleção, garantindo também a compatibilidade total com imagens embutidas e elementos aninhados.