### PR TITLE
78 generalizar a funcionalidade de edição estrutural

### DIFF
--- a/js/shape/ElipseShape.js
+++ b/js/shape/ElipseShape.js
@@ -1,0 +1,83 @@
+import { ShapeBase } from "./ShapeBase.js";
+
+export class ElipseShape extends ShapeBase {
+
+  constructor() {
+    super();
+  }
+
+  renderizarTodosHandles(targetElement, grupoOverlay) {
+    let vertices = [];
+
+    const cx = parseFloat(targetElement.getAttribute('cx'));
+    const cy = parseFloat(targetElement.getAttribute('cy'));
+    const rx = parseFloat(targetElement.getAttribute('rx'));
+    const ry = parseFloat(targetElement.getAttribute('ry'));
+
+    // Define 4 pontos de controle nas extremidades da elipse
+    vertices = [
+        { x: cx, y: cy - ry, id: 'top' },
+        { x: cx + rx, y: cy, id: 'right' },
+        { x: cx, y: cy + ry, id: 'bottom' },
+        { x: cx - rx, y: cy, id: 'left' }
+    ];
+
+    // Renderiza cada vértice identificado usando o método da classe base
+    vertices.forEach(ponto => super.renderizarHandle(ponto, grupoOverlay));
+  }
+
+  atualizarForma(coords, targetElement, activeNode, grupoOverlay) {
+    const cx = parseFloat(targetElement.getAttribute('cx'));
+    const cy = parseFloat(targetElement.getAttribute('cy'));
+    const rx = parseFloat(targetElement.getAttribute('rx'));
+    const ry = parseFloat(targetElement.getAttribute('ry'));
+
+    switch (activeNode) {
+      case 'top':
+        // Altera o raio vertical (ry). Opcionalmente ajusta o cy se quiser travar a base.
+        // Aqui mantemos o centro fixo, que é o padrão matemático mais limpo:
+        targetElement.setAttribute('ry', Math.max(0, cy - coords.y));
+        break;
+
+      case 'right':
+        // Altera o raio horizontal (rx) baseado na distância do centro
+        targetElement.setAttribute('rx', Math.max(0, coords.x - cx));
+        break;
+
+      case 'bottom':
+        // Altera o raio vertical (ry) baseado na distância do centro
+        targetElement.setAttribute('ry', Math.max(0, coords.y - cy));
+        break;
+
+      case 'left':
+        // Altera o raio horizontal (rx) baseado na distância do centro
+        targetElement.setAttribute('rx', Math.max(0, cx - coords.x));
+        break;
+    }
+
+    // Sincroniza os nodes (vértices) com a nova geometria da elipse
+    this.sincronizarTodosOsHandles(targetElement, grupoOverlay);
+  }
+
+  sincronizarTodosOsHandles(targetElement, grupoOverlay) {
+    const cx = parseFloat(targetElement.getAttribute('cx'));
+    const cy = parseFloat(targetElement.getAttribute('cy'));
+    const rx = parseFloat(targetElement.getAttribute('rx'));
+    const ry = parseFloat(targetElement.getAttribute('ry'));
+
+    const posicoes = {
+        'top': { x: cx, y: cy - ry },
+        'right': { x: cx + rx, y: cy },
+        'bottom': { x: cx, y: cy + ry },
+        'left': { x: cx - rx, y: cy }
+    };
+
+    for (const [id, pos] of Object.entries(posicoes)) {
+        const handle = grupoOverlay.querySelector(`[data-node-id="${id}"]`);
+        if (handle) {
+            handle.setAttribute('x', pos.x - 4);
+            handle.setAttribute('y', pos.y - 4);
+        }
+    }
+  }
+}

--- a/js/shape/ElipseShape.js
+++ b/js/shape/ElipseShape.js
@@ -2,11 +2,11 @@ import { ShapeBase } from "./ShapeBase.js";
 
 export class ElipseShape extends ShapeBase {
 
-  constructor() {
-    super();
+  constructor(svgCanvas) {
+    super(svgCanvas);
   }
 
-  renderizarTodosHandles(targetElement, grupoOverlay) {
+  renderizarTodosHandles(targetElement) {
     let vertices = [];
 
     const cx = parseFloat(targetElement.getAttribute('cx'));
@@ -23,10 +23,10 @@ export class ElipseShape extends ShapeBase {
     ];
 
     // Renderiza cada vértice identificado usando o método da classe base
-    vertices.forEach(ponto => super.renderizarHandle(ponto, grupoOverlay));
+    vertices.forEach(ponto => super.renderizarHandle(ponto));
   }
 
-  atualizarForma(coords, targetElement, activeNode, grupoOverlay) {
+  atualizarForma(coords, targetElement, activeNode) {
     const cx = parseFloat(targetElement.getAttribute('cx'));
     const cy = parseFloat(targetElement.getAttribute('cy'));
     const rx = parseFloat(targetElement.getAttribute('rx'));
@@ -34,8 +34,8 @@ export class ElipseShape extends ShapeBase {
 
     switch (activeNode) {
       case 'top':
-        // Altera o raio vertical (ry). Opcionalmente ajusta o cy se quiser travar a base.
-        // Aqui mantemos o centro fixo, que é o padrão matemático mais limpo:
+        // Altera o raio vertical (ry).
+        // Aqui mantenho o centro fixo, que é o padrão matemático mais limpo:
         targetElement.setAttribute('ry', Math.max(0, cy - coords.y));
         break;
 
@@ -55,11 +55,11 @@ export class ElipseShape extends ShapeBase {
         break;
     }
 
-    // Sincroniza os nodes (vértices) com a nova geometria da elipse
-    this.sincronizarTodosOsHandles(targetElement, grupoOverlay);
+    // Sincroniza os nodes (vértices) com a geometria da elipse
+    this.sincronizarTodosOsHandles(targetElement);
   }
 
-  sincronizarTodosOsHandles(targetElement, grupoOverlay) {
+  sincronizarTodosOsHandles(targetElement) {
     const cx = parseFloat(targetElement.getAttribute('cx'));
     const cy = parseFloat(targetElement.getAttribute('cy'));
     const rx = parseFloat(targetElement.getAttribute('rx'));
@@ -73,7 +73,7 @@ export class ElipseShape extends ShapeBase {
     };
 
     for (const [id, pos] of Object.entries(posicoes)) {
-        const handle = grupoOverlay.querySelector(`[data-node-id="${id}"]`);
+        const handle = this.grupoOverlay.querySelector(`[data-node-id="${id}"]`);
         if (handle) {
             handle.setAttribute('x', pos.x - 4);
             handle.setAttribute('y', pos.y - 4);

--- a/js/shape/RetanguloShape.js
+++ b/js/shape/RetanguloShape.js
@@ -1,0 +1,86 @@
+import { ShapeBase } from "./ShapeBase.js";
+
+export class RetanguloShape extends ShapeBase {
+
+  constructor() {
+    super();
+  }
+
+  renderizarTodosHandles(targetElement, grupoOverlay) {
+    let vertices = [];
+
+    const x = parseFloat(targetElement.getAttribute('x'));
+    const y = parseFloat(targetElement.getAttribute('y'));
+    const w = parseFloat(targetElement.getAttribute('width'));
+    const h = parseFloat(targetElement.getAttribute('height'));
+
+    vertices = [
+        { x: x, y: y, id: 'top-left' },
+        { x: x + w, y: y, id: 'top-right' },
+        { x: x + w, y: y + h, id: 'bottom-right' },
+        { x: x, y: y + h, id: 'bottom-left' }
+    ];
+
+    // Renderiza cada vértice identificado
+    vertices.forEach(ponto => super.renderizarHandle(ponto, grupoOverlay));
+  }
+
+  atualizarForma(coords, targetElement, activeNode, grupoOverlay) {
+    const x = parseFloat(targetElement.getAttribute('x'));
+    const y = parseFloat(targetElement.getAttribute('y'));
+    const w = parseFloat(targetElement.getAttribute('width'));
+    const h = parseFloat(targetElement.getAttribute('height'));
+
+    switch (activeNode) {
+      case 'top-left':
+        // Ao mover o topo-esquerdo, mudamos X e Y, e ajustamos W e H
+        targetElement.setAttribute('x', coords.x);
+        targetElement.setAttribute('y', coords.y);
+        targetElement.setAttribute('width', Math.max(0, w + (x - coords.x)));
+        targetElement.setAttribute('height', Math.max(0, h + (y - coords.y)));
+        break;
+
+      case 'top-right':
+          targetElement.setAttribute('y', coords.y);
+          targetElement.setAttribute('width', Math.max(0, coords.x - x));
+          targetElement.setAttribute('height', Math.max(0, h + (y - coords.y)));
+          break;
+
+      case 'bottom-right':
+          targetElement.setAttribute('width', Math.max(0, coords.x - x));
+          targetElement.setAttribute('height', Math.max(0, coords.y - y));
+          break;
+
+      case 'bottom-left':
+          targetElement.setAttribute('x', coords.x);
+          targetElement.setAttribute('width', Math.max(0, w + (x - coords.x)));
+          targetElement.setAttribute('height', Math.max(0, coords.y - y));
+          break;
+    }
+
+    // Sincroniza os nodes (vértices)
+    this.sincronizarTodosOsHandles(targetElement, grupoOverlay);
+  }
+
+  sincronizarTodosOsHandles(targetElement, grupoOverlay){
+    const x = parseFloat(targetElement.getAttribute('x'));
+    const y = parseFloat(targetElement.getAttribute('y'));
+    const w = parseFloat(targetElement.getAttribute('width'));
+    const h = parseFloat(targetElement.getAttribute('height'));
+
+    const posicoes = {
+        'top-left': { x, y },
+        'top-right': { x: x + w, y },
+        'bottom-right': { x: x + w, y: y + h },
+        'bottom-left': { x, y: y + h }
+    };
+
+    for (const [id, pos] of Object.entries(posicoes)) {
+        const handle = grupoOverlay.querySelector(`[data-node-id="${id}"]`);
+        if (handle) {
+            handle.setAttribute('x', pos.x - 4);
+            handle.setAttribute('y', pos.y - 4);
+        }
+    }
+  }
+}

--- a/js/shape/RetanguloShape.js
+++ b/js/shape/RetanguloShape.js
@@ -2,11 +2,11 @@ import { ShapeBase } from "./ShapeBase.js";
 
 export class RetanguloShape extends ShapeBase {
 
-  constructor() {
-    super();
+  constructor(svgCanvas) {
+    super(svgCanvas);
   }
 
-  renderizarTodosHandles(targetElement, grupoOverlay) {
+  renderizarTodosHandles(targetElement) {
     let vertices = [];
 
     const x = parseFloat(targetElement.getAttribute('x'));
@@ -22,10 +22,10 @@ export class RetanguloShape extends ShapeBase {
     ];
 
     // Renderiza cada vértice identificado
-    vertices.forEach(ponto => super.renderizarHandle(ponto, grupoOverlay));
+    vertices.forEach(ponto => super.renderizarHandle(ponto));
   }
 
-  atualizarForma(coords, targetElement, activeNode, grupoOverlay) {
+  atualizarForma(coords, targetElement, activeNode) {
     const x = parseFloat(targetElement.getAttribute('x'));
     const y = parseFloat(targetElement.getAttribute('y'));
     const w = parseFloat(targetElement.getAttribute('width'));
@@ -59,10 +59,10 @@ export class RetanguloShape extends ShapeBase {
     }
 
     // Sincroniza os nodes (vértices)
-    this.sincronizarTodosOsHandles(targetElement, grupoOverlay);
+    this.sincronizarTodosOsHandles(targetElement);
   }
 
-  sincronizarTodosOsHandles(targetElement, grupoOverlay){
+  sincronizarTodosOsHandles(targetElement){
     const x = parseFloat(targetElement.getAttribute('x'));
     const y = parseFloat(targetElement.getAttribute('y'));
     const w = parseFloat(targetElement.getAttribute('width'));
@@ -76,7 +76,7 @@ export class RetanguloShape extends ShapeBase {
     };
 
     for (const [id, pos] of Object.entries(posicoes)) {
-        const handle = grupoOverlay.querySelector(`[data-node-id="${id}"]`);
+        const handle = this.grupoOverlay.querySelector(`[data-node-id="${id}"]`);
         if (handle) {
             handle.setAttribute('x', pos.x - 4);
             handle.setAttribute('y', pos.y - 4);

--- a/js/shape/ShapeBase.js
+++ b/js/shape/ShapeBase.js
@@ -1,0 +1,77 @@
+/**
+ * ShapeBase.js — Classe base abstrata para todas as lógicas de modificação estrutural
+ *
+ * Define a interface (contrato) que cada ferramenta específica deverá implementar.
+ * Ferramentas concretas (ex: RetanguloShape, CirculoShape) devem
+ * estender esta classe e sobrescrever os métodos de estruturação e manipulação.
+ *
+ * @example
+ * import { ShapeBase } from './ShapeBase.js';
+ *
+ * export class RetanguloShape extends ShapeBase {
+ *   renderizarTodosHandles(elemento) { ... }
+ *   onMouseMove(evento) { ... }
+ *   onMouseUp(evento)   { ... }
+ * }
+ */
+export class ShapeBase {
+
+  // Funções que devem ser implementadas pela classe base
+  // renderizarHandle, atualizarPosicaoHandle
+
+  /**
+  * Cria a representação visual (alça) de um vértice no overlay.
+  * @param {Object} ponto - Coordenadas e ID do ponto.
+  */
+  renderizarHandle(ponto) {
+    const handle = criarElementoSVG('rect', {
+      'x': ponto.x - 4, // Centraliza o handle de 8x8 no ponto exato
+      'y': ponto.y - 4,
+      'width': 8,
+      'height': 8,
+      'fill': 'white',
+      'stroke': '#4a90d9',
+      'stroke-width': 1,
+      'style': 'cursor: move;',
+      'class': 'node-handle',
+      'data-node-id': ponto.id
+    });
+  
+    this.grupoOverlay.appendChild(handle);
+  }
+
+  // Move visualmente o quadradinho azul no overlay
+  atualizarPosicaoHandle(coords) {
+    const handle = this.grupoOverlay.querySelector(`[data-node-id="${this.activeNodeId}"]`);
+    if (handle) {
+      handle.setAttribute('x', coords.x - 4);
+      handle.setAttribute('y', coords.y - 4);
+    }
+  }
+  /**
+   * renderiza os pontos estruturais
+   *
+   * @param {SVGAElement} elemento - elemento svg
+   */
+  renderizarTodosHandles(targetElement) {
+    // Deve ser sobrescrito pela ferramenta concreta.
+  }
+
+  /**
+   * Lógica de modificação estrutural da forma
+   *
+   * @param {coordenadas} coordenadas - coordenadas da forma.
+   */
+  atualizarForma(coords) {
+    // Deve ser sobrescrito pela ferramenta concreta.
+  }
+
+  /**
+   * Re-posiciona todas as alças do overlay com base nos novos atributos do elemento alvo.
+   *
+   * @param {SVGAElement} elemento - elemento SVG.
+   */
+  sincronizarTodosOsHandles(targetElement) {
+    // Deve ser sobrescrito pela ferramenta concreta.
+  }
+}

--- a/js/shape/ShapeBase.js
+++ b/js/shape/ShapeBase.js
@@ -3,16 +3,23 @@ import { criarElementoSVG } from "../utils/svgHelpers.js";
 /**
  * ShapeBase.js — Classe base abstrata para todas as lógicas de modificação estrutural
  *
- * Define a interface (contrato) que cada ferramenta específica deverá implementar.
- * Ferramentas concretas (ex: RetanguloShape, CirculoShape) devem
+ * Define a interface (contrato) que cada comportamento específico deverá implementar.
+ * Comportamentos concretos (ex: RetanguloShape, CirculoShape) devem
  * estender esta classe e sobrescrever os métodos de estruturação e manipulação.
+ * 
+ * Alguns métodos já são implementados pela classe pai como:
+ * renderizarHandle: apenas cria um svg de ponto (rect pequeno);
+ * atualizarPosicaoHandle: move o ponto de acordo com o cursor se pressionado;
+ * inicializaOverlay e removeOverlay: cria um svg para renderizar os pontos estruturais
+ * (impede que eles sejam renderizados no elemento principal);
+ * 
  *
  * @example
  * import { ShapeBase } from './ShapeBase.js';
  *
  * export class RetanguloShape extends ShapeBase {
  *   renderizarTodosHandles(elemento) { ... }
- *   atualizarForma(coords) { ... }
+ *   atualizarForma(coords, elemento, noAtivo) { ... }
  *   sincronizarTodosOsHandles(elemento)   { ... }
  * }
  */
@@ -21,11 +28,16 @@ export class ShapeBase {
   // Funções que são implementadas pela classe base
   // renderizarHandle, atualizarPosicaoHandle
 
+  constructor(svgCanvas) {
+    this.grupoOverlay = null;
+    this.svgCanvas = svgCanvas;
+  }
+
   /**
   * Cria a representação visual (alça) de um vértice no overlay.
   * @param {Object} ponto - Coordenadas e ID do ponto.
   */
-  renderizarHandle(ponto, grupoOverlay) {
+  renderizarHandle(ponto) {
     const handle = criarElementoSVG('rect', {
       'x': ponto.x - 4, // Centraliza o handle de 8x8 no ponto exato
       'y': ponto.y - 4,
@@ -39,41 +51,59 @@ export class ShapeBase {
       'data-node-id': ponto.id
     });
   
-    grupoOverlay.appendChild(handle);
+    this.grupoOverlay.appendChild(handle);
   }
 
   // Move visualmente o quadradinho azul no overlay
-  atualizarPosicaoHandle(coords, grupoOverlay) {
-    const handle = grupoOverlay.querySelector(`[data-node-id="${this.activeNodeId}"]`);
+  atualizarPosicaoHandle(coords) {
+    const handle = this.grupoOverlay.querySelector(`[data-node-id="${this.activeNodeId}"]`);
     if (handle) {
       handle.setAttribute('x', coords.x - 4);
       handle.setAttribute('y', coords.y - 4);
     }
   }
+
+  // Cria um grupo SVG para conter as alças de manipulação (Issue #9).
+  inicializarOverlay() {
+    this.grupoOverlay = criarElementoSVG('g', {
+        'id': 'overlay-nodes',
+        'style': 'pointer-events: all;' 
+    });
+    this.svgCanvas.appendChild(this.grupoOverlay);
+  }
+
+  // Remove o grupo svg
+  removeOverlay() {
+    if (this.grupoOverlay) {
+      this.grupoOverlay.remove();
+      this.grupoOverlay = null;
+    }
+  }
+
   /**
    * renderiza os pontos estruturais
    *
-   * @param {SVGAElement} elemento - elemento svg
+   * @param {targetElement} elemento - elemento svg
    */
-  renderizarTodosHandles(targetElement, grupoOverlay) {
+  renderizarTodosHandles(targetElement) {
     // Deve ser sobrescrito pela ferramenta concreta.
   }
 
   /**
    * Lógica de modificação estrutural da forma
    *
-   * @param {coordenadas} coordenadas - coordenadas da forma.
+   * @param {coordenadas, targetElement, activeNode} coordenadas; elemento alvo; nó ativo - coordenadas da forma.
    */
-  atualizarForma(coords, targetElement, activeNode, grupoOverlay) {
+  atualizarForma(coords, targetElement, activeNode) {
     // Deve ser sobrescrito pela ferramenta concreta.
   }
 
   /**
    * Re-posiciona todas as alças do overlay com base nos novos atributos do elemento alvo.
    *
-   * @param {SVGAElement} elemento - elemento SVG.
+   * @param {targetElement} elemento - elemento Alvo.
    */
-  sincronizarTodosOsHandles(targetElement, grupoOverlay) {
+  sincronizarTodosOsHandles(targetElement) {
     // Deve ser sobrescrito pela ferramenta concreta.
   }
 }

--- a/js/shape/ShapeBase.js
+++ b/js/shape/ShapeBase.js
@@ -1,3 +1,5 @@
+import { criarElementoSVG } from "../utils/svgHelpers.js";
+
 /**
  * ShapeBase.js — Classe base abstrata para todas as lógicas de modificação estrutural
  *
@@ -10,20 +12,20 @@
  *
  * export class RetanguloShape extends ShapeBase {
  *   renderizarTodosHandles(elemento) { ... }
- *   onMouseMove(evento) { ... }
- *   onMouseUp(evento)   { ... }
+ *   atualizarForma(coords) { ... }
+ *   sincronizarTodosOsHandles(elemento)   { ... }
  * }
  */
 export class ShapeBase {
 
-  // Funções que devem ser implementadas pela classe base
+  // Funções que são implementadas pela classe base
   // renderizarHandle, atualizarPosicaoHandle
 
   /**
   * Cria a representação visual (alça) de um vértice no overlay.
   * @param {Object} ponto - Coordenadas e ID do ponto.
   */
-  renderizarHandle(ponto) {
+  renderizarHandle(ponto, grupoOverlay) {
     const handle = criarElementoSVG('rect', {
       'x': ponto.x - 4, // Centraliza o handle de 8x8 no ponto exato
       'y': ponto.y - 4,
@@ -37,12 +39,12 @@ export class ShapeBase {
       'data-node-id': ponto.id
     });
   
-    this.grupoOverlay.appendChild(handle);
+    grupoOverlay.appendChild(handle);
   }
 
   // Move visualmente o quadradinho azul no overlay
-  atualizarPosicaoHandle(coords) {
-    const handle = this.grupoOverlay.querySelector(`[data-node-id="${this.activeNodeId}"]`);
+  atualizarPosicaoHandle(coords, grupoOverlay) {
+    const handle = grupoOverlay.querySelector(`[data-node-id="${this.activeNodeId}"]`);
     if (handle) {
       handle.setAttribute('x', coords.x - 4);
       handle.setAttribute('y', coords.y - 4);
@@ -53,7 +55,7 @@ export class ShapeBase {
    *
    * @param {SVGAElement} elemento - elemento svg
    */
-  renderizarTodosHandles(targetElement) {
+  renderizarTodosHandles(targetElement, grupoOverlay) {
     // Deve ser sobrescrito pela ferramenta concreta.
   }
 
@@ -62,7 +64,7 @@ export class ShapeBase {
    *
    * @param {coordenadas} coordenadas - coordenadas da forma.
    */
-  atualizarForma(coords) {
+  atualizarForma(coords, targetElement, activeNode, grupoOverlay) {
     // Deve ser sobrescrito pela ferramenta concreta.
   }
 
@@ -71,7 +73,7 @@ export class ShapeBase {
    *
    * @param {SVGAElement} elemento - elemento SVG.
    */
-  sincronizarTodosOsHandles(targetElement) {
+  sincronizarTodosOsHandles(targetElement, grupoOverlay) {
     // Deve ser sobrescrito pela ferramenta concreta.
   }
 }

--- a/js/tools/ImageImporter.js
+++ b/js/tools/ImageImporter.js
@@ -23,39 +23,27 @@ export function inicializarImportadorImagem(svgCanvas, inputImagem) {
     reader.onload = function(e) {
       const dataUrl = e.target.result; // Imagem em Base64
 
-      // Cria um objeto de imagem HTML em memória para descobrir as dimensões reais
-      const imagemOriginal = new Image();
-
-      imagemOriginal.onload = function() {
-        // Obtém as dimensões originais do arquivo de imagem
-        const larguraOriginal = imagemOriginal.naturalWidth;
-        const alturaOriginal = imagemOriginal.naturalHeight;
-
-        // Cria o elemento <image> nativo do SVG
-        const svgImage = document.createElementNS('http://www.w3.org/2000/svg', 'image');
-        
-        // Define os atributos necessários
-        svgImage.setAttribute('href', dataUrl);
-        svgImage.setAttribute('x', '50');
-        svgImage.setAttribute('y', '50');
-        svgImage.setAttribute('width', larguraOriginal.toString());
-        svgImage.setAttribute('height', alturaOriginal.toString());
-        
-        // O atributo permite a edição estrutural de imagens de forma mais fluida
-        svgImage.setAttribute('preserveAspectRatio', 'none');
+      // Cria o elemento <image> nativo do SVG
+      const svgImage = document.createElementNS('http://www.w3.org/2000/svg', 'image');
       
-        // Classe para que a SelecaoTool reconheça o elemento
-        svgImage.classList.add('elemento-desenho'); 
+      // Define os atributos necessários
+      svgImage.setAttribute('href', dataUrl);
+      svgImage.setAttribute('x', '50');
+      svgImage.setAttribute('y', '50');
+      svgImage.setAttribute('width', '300');
+      svgImage.setAttribute('height', '300');
 
-        // Adiciona a imagem ao canvas
-        svgCanvas.appendChild(svgImage);
+      // O atributo permite a edição estrutural de imagens de forma mais fluida
+      svgImage.setAttribute('preserveAspectRatio', 'none');
+      
+      // Classe para que a SelecaoTool reconheça o elemento
+      svgImage.classList.add('elemento-desenho'); 
 
-        // Limpa o input para permitir importar a mesma imagem novamente
-        inputImagem.value = '';
-      }
+      // Adiciona a imagem ao canvas
+      svgCanvas.appendChild(svgImage);
 
-      // Define o src para disparar o evento onload da imagem em memória
-      imagemOriginal.src = dataUrl;
+      // Limpa o input para permitir importar a mesma imagem novamente
+      inputImagem.value = '';
     };
 
     // Inicia a leitura do arquivo como Data URL

--- a/js/tools/ImageImporter.js
+++ b/js/tools/ImageImporter.js
@@ -23,24 +23,39 @@ export function inicializarImportadorImagem(svgCanvas, inputImagem) {
     reader.onload = function(e) {
       const dataUrl = e.target.result; // Imagem em Base64
 
-      // Cria o elemento <image> nativo do SVG
-      const svgImage = document.createElementNS('http://www.w3.org/2000/svg', 'image');
-      
-      // Define os atributos necessários
-      svgImage.setAttribute('href', dataUrl);
-      svgImage.setAttribute('x', '50');
-      svgImage.setAttribute('y', '50');
-      svgImage.setAttribute('width', '300');
-      svgImage.setAttribute('height', '300');
-      
-      // Classe para que a SelecaoTool reconheça o elemento
-      svgImage.classList.add('elemento-desenho'); 
+      // Cria um objeto de imagem HTML em memória para descobrir as dimensões reais
+      const imagemOriginal = new Image();
 
-      // Adiciona a imagem ao canvas
-      svgCanvas.appendChild(svgImage);
+      imagemOriginal.onload = function() {
+        // Obtém as dimensões originais do arquivo de imagem
+        const larguraOriginal = imagemOriginal.naturalWidth;
+        const alturaOriginal = imagemOriginal.naturalHeight;
 
-      // Limpa o input para permitir importar a mesma imagem novamente
-      inputImagem.value = '';
+        // Cria o elemento <image> nativo do SVG
+        const svgImage = document.createElementNS('http://www.w3.org/2000/svg', 'image');
+        
+        // Define os atributos necessários
+        svgImage.setAttribute('href', dataUrl);
+        svgImage.setAttribute('x', '50');
+        svgImage.setAttribute('y', '50');
+        svgImage.setAttribute('width', larguraOriginal.toString());
+        svgImage.setAttribute('height', alturaOriginal.toString());
+        
+        // O atributo permite a edição estrutural de imagens de forma mais fluida
+        svgImage.setAttribute('preserveAspectRatio', 'none');
+      
+        // Classe para que a SelecaoTool reconheça o elemento
+        svgImage.classList.add('elemento-desenho'); 
+
+        // Adiciona a imagem ao canvas
+        svgCanvas.appendChild(svgImage);
+
+        // Limpa o input para permitir importar a mesma imagem novamente
+        inputImagem.value = '';
+      }
+
+      // Define o src para disparar o evento onload da imagem em memória
+      imagemOriginal.src = dataUrl;
     };
 
     // Inicia a leitura do arquivo como Data URL

--- a/js/tools/NodeEditTool.js
+++ b/js/tools/NodeEditTool.js
@@ -90,7 +90,7 @@ export class NodeEditTool extends ToolBase {
     }
 
     // Identifica os pontos e solicita a renderização.
-    identificarVertices() {
+    renderizarTodosHandles() {
         let vertices = [];
 
         if (this.elementoAlvo.tagName === 'rect') {

--- a/js/tools/NodeEditTool.js
+++ b/js/tools/NodeEditTool.js
@@ -12,15 +12,14 @@ export class NodeEditTool extends ToolBase {
         super();
         this.svgCanvas = svgCanvas;
         this.elementoAlvo = null;
-        this.grupoOverlay = null;
 
         // Estado do arraste
         this.isDraggingNode = false;
         this.activeNodeId = null;
         this.allowedShapes = {
-            'rect': new RetanguloShape(),
-            'ellipse': new ElipseShape(),
-            'image': new RetanguloShape(), // Image possui as mesmas propriedades de retangulos
+            'rect': new RetanguloShape(svgCanvas),
+            'ellipse': new ElipseShape(svgCanvas),
+            'image': new RetanguloShape(svgCanvas), // Image possui as mesmas propriedades de retangulos
         }
     }
 
@@ -30,9 +29,10 @@ export class NodeEditTool extends ToolBase {
     onMouseDown(evento) {
         const pt = obterCoordenadaSVG(evento, this.svgCanvas);
         const target = evento.target;
+        let shape = this.elementoAlvo ? this.allowedShapes[this.elementoAlvo.tagName] : null;
 
         // Verifica se o clique foi em um handle de nó
-        if (this.grupoOverlay && this.grupoOverlay.contains(target)) {
+        if (shape && shape.grupoOverlay && shape.grupoOverlay.contains(target)) {
             this.isDraggingNode = true;
             this.activeNodeId = target.getAttribute('data-node-id');
             
@@ -40,8 +40,10 @@ export class NodeEditTool extends ToolBase {
             evento.stopPropagation();
             return;
         }
+
         this.limparSelecao();
         const tag = target.tagName ? target.tagName.toLowerCase() : '';
+        let newShape = this.allowedShapes[tag];
 
         // Se o clique não foi no canvas vazio e for um elemento permitido
         if (
@@ -54,8 +56,8 @@ export class NodeEditTool extends ToolBase {
         }
         
         if (this.elementoAlvo) {
-            this.inicializarOverlay();
-            this.allowedShapes[tag].renderizarTodosHandles(this.elementoAlvo, this.grupoOverlay);
+            newShape.inicializarOverlay();
+            newShape.renderizarTodosHandles(this.elementoAlvo);
         } 
     }
 
@@ -67,8 +69,9 @@ export class NodeEditTool extends ToolBase {
 
         // No onMouseMove de NodeEditTool.js altere para:
         const tag = this.elementoAlvo.tagName.toLowerCase();
-        this.allowedShapes[tag].atualizarPosicaoHandle(coordenadas, this.grupoOverlay);
-        this.allowedShapes[tag].atualizarForma(coordenadas, this.elementoAlvo, this.activeNodeId, this.grupoOverlay);
+        const shape = this.allowedShapes[tag];
+        shape.atualizarPosicaoHandle(coordenadas);
+        shape.atualizarForma(coordenadas, this.elementoAlvo, this.activeNodeId);
     }
 
     //Finaliza o arraste
@@ -82,20 +85,9 @@ export class NodeEditTool extends ToolBase {
         this.limparSelecao();
     }
 
-     // Cria um grupo SVG para conter as alças de manipulação (Issue #9).
-    inicializarOverlay() {
-        this.grupoOverlay = criarElementoSVG('g', {
-            'id': 'overlay-nodes',
-            'style': 'pointer-events: all;' 
-        });
-        this.svgCanvas.appendChild(this.grupoOverlay);
-    }
-
     limparSelecao() {
-        if (this.grupoOverlay) {
-            this.grupoOverlay.remove();
-            this.grupoOverlay = null;
-        }
+        const tag = this.elementoAlvo ? this.elementoAlvo.tagName : '';
+        if (tag) this.allowedShapes[tag].removeOverlay();
         this.elementoAlvo = null;
       }
     

--- a/js/tools/NodeEditTool.js
+++ b/js/tools/NodeEditTool.js
@@ -20,6 +20,7 @@ export class NodeEditTool extends ToolBase {
         this.allowedShapes = {
             'rect': new RetanguloShape(),
             'ellipse': new ElipseShape(),
+            'image': new RetanguloShape(), // Image possui as mesmas propriedades de retangulos
         }
     }
 

--- a/js/tools/NodeEditTool.js
+++ b/js/tools/NodeEditTool.js
@@ -1,5 +1,6 @@
 import { ToolBase } from './ToolBase.js';
 import { obterCoordenadaSVG, criarElementoSVG } from '../utils/svgHelpers.js';
+import { RetanguloShape } from '../shape/RetanguloShape.js';
 
 /**
  * NodeEditTool
@@ -15,6 +16,9 @@ export class NodeEditTool extends ToolBase {
         // Estado do arraste
         this.isDraggingNode = false;
         this.activeNodeId = null;
+        this.allowedShapes = {
+            'rect': new RetanguloShape(),
+        }
     }
 
     /**
@@ -34,15 +38,13 @@ export class NodeEditTool extends ToolBase {
             return;
         }
         this.limparSelecao();
-
-        const allowedTags = ['rect'];
         const tag = target.tagName ? target.tagName.toLowerCase() : '';
 
         // Se o clique não foi no canvas vazio e for um elemento permitido
         if (
             target !== this.svgCanvas &&
             target.parentNode === this.svgCanvas &&
-            allowedTags.includes(tag)
+            Object.keys(this.allowedShapes).includes(tag)
         ) {
             // Verifica se há algo selecionado no estado global
             this.elementoAlvo = target;
@@ -50,7 +52,7 @@ export class NodeEditTool extends ToolBase {
         
         if (this.elementoAlvo) {
             this.inicializarOverlay();
-            this.identificarVertices();
+            this.allowedShapes[tag].renderizarTodosHandles(this.elementoAlvo, this.grupoOverlay);
         } 
     }
 
@@ -62,11 +64,9 @@ export class NodeEditTool extends ToolBase {
 
         // Por enquanto, apenas movemos visualmente a alça no overlay
         // No próximo passo (Passo 4), conectaremos isso à forma real
-        this.atualizarPosicaoHandle(coordenadas);
+        this.allowedShapes[this.elementoAlvo.tagName].atualizarPosicaoHandle(coordenadas, this.grupoOverlay);
         // Atualiza a geometria da forma real
-        if (this.elementoAlvo.tagName === 'rect') {
-            this.atualizarRetangulo(coordenadas);
-        }
+        this.allowedShapes[this.elementoAlvo.tagName].atualizarForma(coordenadas, this.elementoAlvo, this.activeNodeId, this.grupoOverlay);
     }
 
     //Finaliza o arraste
@@ -87,121 +87,6 @@ export class NodeEditTool extends ToolBase {
             'style': 'pointer-events: all;' 
         });
         this.svgCanvas.appendChild(this.grupoOverlay);
-    }
-
-    // Identifica os pontos e solicita a renderização.
-    renderizarTodosHandles() {
-        let vertices = [];
-
-        if (this.elementoAlvo.tagName === 'rect') {
-            const x = parseFloat(this.elementoAlvo.getAttribute('x'));
-            const y = parseFloat(this.elementoAlvo.getAttribute('y'));
-            const w = parseFloat(this.elementoAlvo.getAttribute('width'));
-            const h = parseFloat(this.elementoAlvo.getAttribute('height'));
-
-            vertices = [
-                { x: x, y: y, id: 'top-left' },
-                { x: x + w, y: y, id: 'top-right' },
-                { x: x + w, y: y + h, id: 'bottom-right' },
-                { x: x, y: y + h, id: 'bottom-left' }
-            ];
-        }
-
-        // Renderiza cada vértice identificado
-        vertices.forEach(ponto => this.renderizarHandle(ponto));
-    }
-
-    /**
-     * Cria a representação visual (alça) de um vértice no overlay.
-     * @param {Object} ponto - Coordenadas e ID do ponto.
-     */
-    renderizarHandle(ponto) {
-        const handle = criarElementoSVG('rect', {
-            'x': ponto.x - 4, // Centraliza o handle de 8x8 no ponto exato
-            'y': ponto.y - 4,
-            'width': 8,
-            'height': 8,
-            'fill': 'white',
-            'stroke': '#4a90d9',
-            'stroke-width': 1,
-            'style': 'cursor: move;',
-            'class': 'node-handle',
-            'data-node-id': ponto.id
-        });
-
-        this.grupoOverlay.appendChild(handle);
-    }
-
-    // Move visualmente o quadradinho azul no overlay
-    atualizarPosicaoHandle(coords) {
-        const handle = this.grupoOverlay.querySelector(`[data-node-id="${this.activeNodeId}"]`);
-        if (handle) {
-            handle.setAttribute('x', coords.x - 4);
-            handle.setAttribute('y', coords.y - 4);
-        }
-    }
-
-    // Lógica matemática para redimensionar o retângulo com base no vértice arrastado.
-    atualizarRetangulo(coords) {
-        const x = parseFloat(this.elementoAlvo.getAttribute('x'));
-        const y = parseFloat(this.elementoAlvo.getAttribute('y'));
-        const w = parseFloat(this.elementoAlvo.getAttribute('width'));
-        const h = parseFloat(this.elementoAlvo.getAttribute('height'));
-
-        switch (this.activeNodeId) {
-            case 'top-left':
-                // Ao mover o topo-esquerdo, mudamos X e Y, e ajustamos W e H
-                this.elementoAlvo.setAttribute('x', coords.x);
-                this.elementoAlvo.setAttribute('y', coords.y);
-                this.elementoAlvo.setAttribute('width', Math.max(0, w + (x - coords.x)));
-                this.elementoAlvo.setAttribute('height', Math.max(0, h + (y - coords.y)));
-                break;
-
-            case 'top-right':
-                this.elementoAlvo.setAttribute('y', coords.y);
-                this.elementoAlvo.setAttribute('width', Math.max(0, coords.x - x));
-                this.elementoAlvo.setAttribute('height', Math.max(0, h + (y - coords.y)));
-                break;
-
-            case 'bottom-right':
-                this.elementoAlvo.setAttribute('width', Math.max(0, coords.x - x));
-                this.elementoAlvo.setAttribute('height', Math.max(0, coords.y - y));
-                break;
-
-            case 'bottom-left':
-                this.elementoAlvo.setAttribute('x', coords.x);
-                this.elementoAlvo.setAttribute('width', Math.max(0, w + (x - coords.x)));
-                this.elementoAlvo.setAttribute('height', Math.max(0, coords.y - y));
-                break;
-        }
-
-        // Sincroniza os nodes (vértices)
-        this.sincronizarTodosOsHandles();
-    }
-
-    // Re-posiciona todas as alças do overlay com base nos novos atributos do elemento alvo.
-    sincronizarTodosOsHandles() {
-        if (this.elementoAlvo.tagName === 'rect') {
-            const x = parseFloat(this.elementoAlvo.getAttribute('x'));
-            const y = parseFloat(this.elementoAlvo.getAttribute('y'));
-            const w = parseFloat(this.elementoAlvo.getAttribute('width'));
-            const h = parseFloat(this.elementoAlvo.getAttribute('height'));
-
-            const posicoes = {
-                'top-left': { x, y },
-                'top-right': { x: x + w, y },
-                'bottom-right': { x: x + w, y: y + h },
-                'bottom-left': { x, y: y + h }
-            };
-
-            for (const [id, pos] of Object.entries(posicoes)) {
-                const handle = this.grupoOverlay.querySelector(`[data-node-id="${id}"]`);
-                if (handle) {
-                    handle.setAttribute('x', pos.x - 4);
-                    handle.setAttribute('y', pos.y - 4);
-                }
-            }
-        }
     }
 
     limparSelecao() {

--- a/js/tools/NodeEditTool.js
+++ b/js/tools/NodeEditTool.js
@@ -1,6 +1,7 @@
 import { ToolBase } from './ToolBase.js';
 import { obterCoordenadaSVG, criarElementoSVG } from '../utils/svgHelpers.js';
 import { RetanguloShape } from '../shape/RetanguloShape.js';
+import { ElipseShape } from '../shape/ElipseShape.js';
 
 /**
  * NodeEditTool
@@ -18,6 +19,7 @@ export class NodeEditTool extends ToolBase {
         this.activeNodeId = null;
         this.allowedShapes = {
             'rect': new RetanguloShape(),
+            'ellipse': new ElipseShape(),
         }
     }
 
@@ -62,11 +64,10 @@ export class NodeEditTool extends ToolBase {
 
         const coordenadas = obterCoordenadaSVG(evento, this.svgCanvas);
 
-        // Por enquanto, apenas movemos visualmente a alça no overlay
-        // No próximo passo (Passo 4), conectaremos isso à forma real
-        this.allowedShapes[this.elementoAlvo.tagName].atualizarPosicaoHandle(coordenadas, this.grupoOverlay);
-        // Atualiza a geometria da forma real
-        this.allowedShapes[this.elementoAlvo.tagName].atualizarForma(coordenadas, this.elementoAlvo, this.activeNodeId, this.grupoOverlay);
+        // No onMouseMove de NodeEditTool.js altere para:
+        const tag = this.elementoAlvo.tagName.toLowerCase();
+        this.allowedShapes[tag].atualizarPosicaoHandle(coordenadas, this.grupoOverlay);
+        this.allowedShapes[tag].atualizarForma(coordenadas, this.elementoAlvo, this.activeNodeId, this.grupoOverlay);
     }
 
     //Finaliza o arraste


### PR DESCRIPTION
@gustavoresque Terminei de realizar as alterações para generalizar a ferramenta de edição de formas por meio de pontos de arraste. O que foi realizado:

- **Desacoplamento:** No modelo antigo, a ferramenta NodeEditTool era responsável por toda a lógica, gerenciando tanto os eventos de interação quanto o comportamento estrutural das formas. Para resolver isso, migrei todas as funções de comportamento geométrico para a nova classe abstrata ShapeBase, removendo essa responsabilidade da ferramenta. Agora, a NodeEditTool acessa esses comportamentos exclusivamente por meio de métodos expostos pelas instâncias das classes que herdam de ShapeBase.

- **NodeEditTool:** Agora possui estritamente métodos de ciclo de vida e eventos (como onMouseDown, onMouseMove, onMouseUp, etc.), além de um método para limpeza de estado. Também foi adicionado o atributo allowedShapes, que mapeia as tags dos elementos às suas respectivas instâncias de comportamento em um formato chave-valor (ex: chave: tagName, valor: nova classe que herda de ShapeBase).

- **Estrutura e Família ShapeBase:** Criei um novo diretório chamado shape para organizar as classes de comportamento que estendem ShapeBase. Foram implementadas as classes RetanguloShape e ElipseShape (vale destacar que o elemento <*image*> foi mapeado para a RetanguloShape, pois ambos compartilham as mesmas propriedades dimensionais no SVG).

- **Principais métodos de ShapeBase:** renderizarTodosHandles, atualizarForma e sincronizarTodosOsHandles.

- **Ajuste no ImageImporter:** Para garantir que as imagens pudessem ser manipuladas e distorcidas corretamente pela ferramenta, apliquei duas melhorias no serviço de importação:

  - Adição do atributo preserveAspectRatio="none".

  - Alteração no fluxo de leitura do arquivo para que a tag <image> seja renderizada utilizando suas dimensões reais (naturalWidth e naturalHeight), em vez de um tamanho fixo padronizado.

- **Elementos disponíveis para testes:** <*ellipse*>, <*rect*> e <*image*>.