### PR TITLE
fix(issue-84): resolve tela branca ao carregar SVG usando importNode

### DIFF
--- a/js/core/UIManager.js
+++ b/js/core/UIManager.js
@@ -7,7 +7,7 @@ import { definirInterface } from './StateManager.js';
 export function inicializarMenuInicial(svgCanvas) {
     const telaInicial = document.getElementById('tela-inicial');
     const telaEditor = document.getElementById('app');
-    
+
     const btnNovoDoc = document.getElementById('btn-novo-doc');
     const btnAbrirArq = document.getElementById('btn-abrir-arq');
     const selectTamanho = document.getElementById('select-tamanho');
@@ -22,7 +22,7 @@ export function inicializarMenuInicial(svgCanvas) {
     // 1. Lógica: Criar Novo Documento
     btnNovoDoc.addEventListener('click', () => {
         const tamanho = selectTamanho.value;
-        
+
         // Aplica o tamanho selecionado alterando a ViewBox do SVG
         if (tamanho === 'a4') {
             svgCanvas.setAttribute('viewBox', '0 0 800 1131');
@@ -35,7 +35,7 @@ export function inicializarMenuInicial(svgCanvas) {
             svgCanvas.removeAttribute('viewBox');
             svgCanvas.style.backgroundColor = 'var(--cor-fundo-canvas)';
         }
-        
+
         // Garante que começamos com um canvas limpo
         svgCanvas.innerHTML = '';
         irParaEditor();
@@ -43,7 +43,6 @@ export function inicializarMenuInicial(svgCanvas) {
 
     // 2. Lógica: Abrir Arquivo (Lê um SVG do computador do usuário)
     btnAbrirArq.addEventListener('click', () => {
-        // Criamos um input de arquivo invisível dinamicamente
         const inputFalso = document.createElement('input');
         inputFalso.type = 'file';
         inputFalso.accept = '.svg';
@@ -55,27 +54,50 @@ export function inicializarMenuInicial(svgCanvas) {
             const leitor = new FileReader();
             leitor.onload = (e) => {
                 const conteudoSvg = e.target.result;
-                
+
                 // Transforma o texto do arquivo lido em Elementos DOM de verdade
                 const parser = new DOMParser();
                 const docSvg = parser.parseFromString(conteudoSvg, "image/svg+xml");
+
+                // Validação de parsing para evitar tela branca em arquivos corrompidos
+                const erroParse = docSvg.querySelector('parsererror');
+                if (erroParse) {
+                    console.error('Erro na leitura do arquivo SVG:', erroParse);
+                    alert('Arquivo SVG inválido ou corrompido.');
+                    return;
+                }
+
                 const svgImportado = docSvg.documentElement;
 
-                // Injeta o conteúdo no nosso canvas
-                svgCanvas.innerHTML = svgImportado.innerHTML;
-                
+                // Limpa o canvas original de forma segura
+                svgCanvas.innerHTML = '';
+
+                // Transfere cada nó diretamente clonando de forma exata o namespace vetorial
+                Array.from(svgImportado.childNodes).forEach(node => {
+                    const clone = document.importNode(node, true);
+                    svgCanvas.appendChild(clone);
+                });
+
                 // Preserva o viewBox original do arquivo, se existir
                 if (svgImportado.hasAttribute('viewBox')) {
                     svgCanvas.setAttribute('viewBox', svgImportado.getAttribute('viewBox'));
+                } else {
+                    svgCanvas.removeAttribute('viewBox'); // Previne conflitos com o viewBox anterior
                 }
-                
-                irParaEditor();
+
+                // Restaura o background para impedir que elementos fiquem invisíveis em matrizes escuras
+                svgCanvas.style.backgroundColor = 'var(--cor-fundo-canvas)';
+
+                irParaEditor(); //
             };
             leitor.readAsText(arquivo);
         });
 
-        // Simula o clique do usuário para abrir a janela do Windows/Linux
-        inputFalso.click(); 
+        // Adicionar o input temporariamente ao body garante a execução plena do File API do navegador
+        inputFalso.style.display = 'none';
+        document.body.appendChild(inputFalso);
+        inputFalso.click();
+        document.body.removeChild(inputFalso);
     });
 
     // 3. Stubs (Para as futuras issues)


### PR DESCRIPTION
Resolves #84
Correção do problema de tela branca ao carregar arquivos SVG salvos pelo usuário. O DOMParser foi ajustado para clonar os nós vetoriais e preservar o namespace correto durante a injeção no canvas principal.

Reivindicação de Badge
Acredito que mereço a badge 🐛 Bug Catcher pois identifiquei e resolvi um erro crítico de renderização no carregamento de arquivos que travava a aplicação e deixava a tela em branco.

Review
Pronto para avaliação. Solicito a revisão de @gustavoresque.