### PR TITLE
104 bug fix borracha com trajetoria

### DIFF
--- a/js/tools/BorrachaTool.js
+++ b/js/tools/BorrachaTool.js
@@ -74,4 +74,51 @@ export class BorrachaTool extends ToolBase {
       y: transformed.y
     };
   }
+
+  /**
+   * Apaga elementos atingidos por um segmento da trajetória
+   */
+  apagarSegmento(p1, p2) {
+    const elementos = Array.from(this.svgCanvas.children);
+
+    for (const elemento of elementos) {
+      const tag = elemento.tagName?.toLowerCase();
+
+      if (!this.allowedTags.includes(tag)) {
+        continue;
+      }
+
+      if (this.segmentoInterceptaElemento(p1, p2, elemento)) {
+        elemento.remove();
+      }
+    }
+  }
+
+
+
+  /**
+   * Verifica se um segmento intercepta o bounding box do elemento
+   */
+  segmentoInterceptaElemento(p1, p2, elemento) {
+    const bbox = elemento.getBBox();
+
+    const x1 = bbox.x;
+    const y1 = bbox.y;
+    const x2 = bbox.x + bbox.width;
+    const y2 = bbox.y + bbox.height;
+
+    if (this.pontoDentroBBox(p1, bbox)) return true;
+    if (this.pontoDentroBBox(p2, bbox)) return true;
+
+    const edges = [
+      [{ x: x1, y: y1 }, { x: x2, y: y1 }],
+      [{ x: x2, y: y1 }, { x: x2, y: y2 }],
+      [{ x: x2, y: y2 }, { x: x1, y: y2 }],
+      [{ x: x1, y: y2 }, { x: x1, y: y1 }]
+    ];
+
+    return edges.some(([a, b]) =>
+      this.segmentosIntersectam(p1, p2, a, b)
+    );
+  }
 }

--- a/js/tools/BorrachaTool.js
+++ b/js/tools/BorrachaTool.js
@@ -37,7 +37,13 @@ export class BorrachaTool extends ToolBase {
 
   onMouseMove(evento) {
     if (!this.isErasing) return;
-    this.apagarElemento(evento);
+
+    const currentPoint = this.getSvgPoint(evento);
+    const lastPoint = this.pathPoints[this.pathPoints.length - 1];
+
+    this.pathPoints.push(currentPoint);
+
+    this.apagarSegmento(lastPoint, currentPoint);
   }
 
   onMouseUp() {

--- a/js/tools/BorrachaTool.js
+++ b/js/tools/BorrachaTool.js
@@ -122,6 +122,14 @@ export class BorrachaTool extends ToolBase {
     );
   }
 
+  pontoDentroBBox(point, bbox) {
+    return (
+      point.x >= bbox.x &&
+      point.x <= bbox.x + bbox.width &&
+      point.y >= bbox.y &&
+      point.y <= bbox.y + bbox.height
+    );
+  }
 
   segmentosIntersectam(p1, p2, p3, p4) {
     const det =

--- a/js/tools/BorrachaTool.js
+++ b/js/tools/BorrachaTool.js
@@ -42,21 +42,7 @@ export class BorrachaTool extends ToolBase {
 
   onMouseUp() {
     this.isErasing = false;
-  }
-
-  apagarElemento(evento) {
-    const target = evento.target;
-
-    const allowedTags = ['rect', 'text', 'image', 'circle', 'ellipse', 'line', 'path', 'polygon', 'polyline'];
-    const tag = target.tagName ? target.tagName.toLowerCase() : '';
-
-    if (
-      target !== this.svgCanvas &&
-      target.parentNode === this.svgCanvas &&
-      allowedTags.includes(tag)
-    ) {
-      target.remove();
-    }
+    this.pathPoints = [];
   }
 
   onDesativar() {

--- a/js/tools/BorrachaTool.js
+++ b/js/tools/BorrachaTool.js
@@ -3,7 +3,8 @@ import { ToolBase } from './ToolBase.js';
 /**
  * Ferramenta Borracha
  *
- * Remove elementos do canvas SVG ao clicar ou arrastar.
+ * Remove elementos do canvas SVG utilizando a trajetória
+ * percorrida pelo cursor ou ao clicar.
  */
 export class BorrachaTool extends ToolBase {
   constructor(svgCanvas) {

--- a/js/tools/BorrachaTool.js
+++ b/js/tools/BorrachaTool.js
@@ -99,25 +99,29 @@ export class BorrachaTool extends ToolBase {
    * Apaga elementos diretamente sob o cursor
    */
   apagarNaPosicao(point) {
-    const elementos = Array.from(this.svgCanvas.children);
-
-    for (const elemento of elementos) {
-      const tag = elemento.tagName?.toLowerCase();
-
-      if (!this.allowedTags.includes(tag)) {
-        continue;
-      }
-
-      const bbox = elemento.getBBox();
-
-      if (
-        point.x >= bbox.x &&
-        point.x <= bbox.x + bbox.width &&
-        point.y >= bbox.y &&
-        point.y <= bbox.y + bbox.height
-      ) {
-        elemento.remove();
-      }
+    const svgPoint = this.svgCanvas.createSVGPoint();
+  
+    svgPoint.x = point.x;
+    svgPoint.y = point.y;
+  
+    const screenPoint = svgPoint.matrixTransform(
+      this.svgCanvas.getScreenCTM()
+    );
+  
+    const elemento = document.elementFromPoint(
+      screenPoint.x,
+      screenPoint.y
+    );
+  
+    const tag = elemento?.tagName?.toLowerCase();
+  
+    if (
+      elemento &&
+      elemento !== this.svgCanvas &&
+      elemento.parentNode === this.svgCanvas &&
+      this.allowedTags.includes(tag)
+    ) {
+      elemento.remove();
     }
   }
 

--- a/js/tools/BorrachaTool.js
+++ b/js/tools/BorrachaTool.js
@@ -10,11 +10,29 @@ export class BorrachaTool extends ToolBase {
     super();
     this.svgCanvas = svgCanvas;
     this.isErasing = false;
+    this.pathPoints = [];
+
+    this.allowedTags = [
+      'rect',
+      'text',
+      'image',
+      'circle',
+      'ellipse',
+      'line',
+      'path',
+      'polygon',
+      'polyline'
+    ];
   }
 
   onMouseDown(evento) {
     this.isErasing = true;
-    this.apagarElemento(evento);
+
+    this.pathPoints = [
+      this.getSvgPoint(evento)
+    ];
+
+    this.apagarNaPosicao(this.pathPoints[0]);
   }
 
   onMouseMove(evento) {
@@ -22,7 +40,7 @@ export class BorrachaTool extends ToolBase {
     this.apagarElemento(evento);
   }
 
-  onMouseUp(evento) {
+  onMouseUp() {
     this.isErasing = false;
   }
 

--- a/js/tools/BorrachaTool.js
+++ b/js/tools/BorrachaTool.js
@@ -80,17 +80,28 @@ export class BorrachaTool extends ToolBase {
    * Apaga elementos atingidos por um segmento da trajetória
    */
   apagarSegmento(p1, p2) {
-    const elementos = Array.from(this.svgCanvas.children);
+    const distancia = Math.hypot(p2.x - p1.x, p2.y - p1.y);
+    const passos = Math.max(1, Math.ceil(distancia / 2));
 
-    for (const elemento of elementos) {
-      const tag = elemento.tagName?.toLowerCase();
+    for (let i = 0; i <= passos; i++) {
+      const t = i / passos;
 
-      if (!this.allowedTags.includes(tag)) {
-        continue;
-      }
+      const pontoSvg = this.svgCanvas.createSVGPoint();
+      pontoSvg.x = p1.x + (p2.x - p1.x) * t;
+      pontoSvg.y = p1.y + (p2.y - p1.y) * t;
 
-      if (this.segmentoInterceptaElemento(p1, p2, elemento)) {
-        elemento.remove();
+      const pontoTela = pontoSvg.matrixTransform(this.svgCanvas.getScreenCTM());
+      const elemento = document.elementFromPoint(pontoTela.x, pontoTela.y);
+
+      if (
+        elemento &&
+        elemento !== this.svgCanvas &&
+        elemento.parentNode === this.svgCanvas
+      ) {
+        const tag = elemento.tagName?.toLowerCase();
+        if (this.allowedTags.includes(tag)) {
+          elemento.remove();
+        }
       }
     }
   }

--- a/js/tools/BorrachaTool.js
+++ b/js/tools/BorrachaTool.js
@@ -122,64 +122,37 @@ export class BorrachaTool extends ToolBase {
   }
 
   /**
-   * Verifica se um segmento intercepta o bounding box do elemento
+   * Verifica se um segmento intercepta o elemento
    */
   segmentoInterceptaElemento(p1, p2, elemento) {
-    const bbox = elemento.getBBox();
-
-    const x1 = bbox.x;
-    const y1 = bbox.y;
-    const x2 = bbox.x + bbox.width;
-    const y2 = bbox.y + bbox.height;
-
-    if (this.pontoDentroBBox(p1, bbox)) return true;
-    if (this.pontoDentroBBox(p2, bbox)) return true;
-
-    const edges = [
-      [{ x: x1, y: y1 }, { x: x2, y: y1 }],
-      [{ x: x2, y: y1 }, { x: x2, y: y2 }],
-      [{ x: x2, y: y2 }, { x: x1, y: y2 }],
-      [{ x: x1, y: y2 }, { x: x1, y: y1 }]
-    ];
-
-    return edges.some(([a, b]) =>
-      this.segmentosIntersectam(p1, p2, a, b)
+    const distancia = Math.hypot(
+      p2.x - p1.x,
+      p2.y - p1.y
     );
-  }
-
-  pontoDentroBBox(point, bbox) {
-    return (
-      point.x >= bbox.x &&
-      point.x <= bbox.x + bbox.width &&
-      point.y >= bbox.y &&
-      point.y <= bbox.y + bbox.height
-    );
-  }
-
-  segmentosIntersectam(p1, p2, p3, p4) {
-    const det =
-      (p2.x - p1.x) * (p4.y - p3.y) -
-      (p2.y - p1.y) * (p4.x - p3.x);
-
-    if (det === 0) {
-      return false;
+  
+    const passos = Math.max(1, Math.ceil(distancia / 2));
+  
+    for (let i = 0; i <= passos; i++) {
+      const t = i / passos;
+    
+      const pontoSvg = this.svgCanvas.createSVGPoint();
+      pontoSvg.x = p1.x + (p2.x - p1.x) * t;
+      pontoSvg.y = p1.y + (p2.y - p1.y) * t;
+    
+      const pontoTela = pontoSvg.matrixTransform(
+        this.svgCanvas.getScreenCTM()
+      );
+    
+      const target = document.elementFromPoint(
+        pontoTela.x,
+        pontoTela.y
+      );
+    
+      if (target === elemento) {
+        return true;
+      }
     }
-
-    const lambda =
-      ((p4.y - p3.y) * (p4.x - p1.x) +
-        (p3.x - p4.x) * (p4.y - p1.y)) /
-      det;
-
-    const gamma =
-      ((p1.y - p2.y) * (p4.x - p1.x) +
-        (p2.x - p1.x) * (p4.y - p1.y)) /
-      det;
-
-    return (
-      lambda >= 0 &&
-      lambda <= 1 &&
-      gamma >= 0 &&
-      gamma <= 1
-    );
+  
+    return false;
   }
 }

--- a/js/tools/BorrachaTool.js
+++ b/js/tools/BorrachaTool.js
@@ -47,5 +47,25 @@ export class BorrachaTool extends ToolBase {
 
   onDesativar() {
     this.isErasing = false;
+    this.pathPoints = [];
+  }
+
+  /**
+   * Converte coordenadas da tela para coordenadas SVG
+   */
+  getSvgPoint(evento) {
+    const pt = this.svgCanvas.createSVGPoint();
+
+    pt.x = evento.clientX;
+    pt.y = evento.clientY;
+
+    const transformed = pt.matrixTransform(
+      this.svgCanvas.getScreenCTM().inverse()
+    );
+
+    return {
+      x: transformed.x,
+      y: transformed.y
+    };
   }
 }

--- a/js/tools/BorrachaTool.js
+++ b/js/tools/BorrachaTool.js
@@ -94,7 +94,31 @@ export class BorrachaTool extends ToolBase {
     }
   }
 
+  /**
+   * Apaga elementos diretamente sob o cursor
+   */
+  apagarNaPosicao(point) {
+    const elementos = Array.from(this.svgCanvas.children);
 
+    for (const elemento of elementos) {
+      const tag = elemento.tagName?.toLowerCase();
+
+      if (!this.allowedTags.includes(tag)) {
+        continue;
+      }
+
+      const bbox = elemento.getBBox();
+
+      if (
+        point.x >= bbox.x &&
+        point.x <= bbox.x + bbox.width &&
+        point.y >= bbox.y &&
+        point.y <= bbox.y + bbox.height
+      ) {
+        elemento.remove();
+      }
+    }
+  }
 
   /**
    * Verifica se um segmento intercepta o bounding box do elemento

--- a/js/tools/BorrachaTool.js
+++ b/js/tools/BorrachaTool.js
@@ -121,4 +121,32 @@ export class BorrachaTool extends ToolBase {
       this.segmentosIntersectam(p1, p2, a, b)
     );
   }
+
+
+  segmentosIntersectam(p1, p2, p3, p4) {
+    const det =
+      (p2.x - p1.x) * (p4.y - p3.y) -
+      (p2.y - p1.y) * (p4.x - p3.x);
+
+    if (det === 0) {
+      return false;
+    }
+
+    const lambda =
+      ((p4.y - p3.y) * (p4.x - p1.x) +
+        (p3.x - p4.x) * (p4.y - p1.y)) /
+      det;
+
+    const gamma =
+      ((p1.y - p2.y) * (p4.x - p1.x) +
+        (p2.x - p1.x) * (p4.y - p1.y)) /
+      det;
+
+    return (
+      lambda >= 0 &&
+      lambda <= 1 &&
+      gamma >= 0 &&
+      gamma <= 1
+    );
+  }
 }


### PR DESCRIPTION
# Resumo

Esta PR refatora a ferramenta Borracha para utilizar a trajetória do cursor durante o apagamento, eliminando a dependência de event.target.

# Problema Resolvido

Anteriormente, a remoção dependia exclusivamente do elemento presente em event.target. Durante movimentos rápidos do cursor, alguns elementos podiam ser ignorados, pois nenhum evento de movimento era disparado diretamente sobre eles.

Com esta alteração, a ferramenta passa a considerar todo o trajeto percorrido pelo cursor, garantindo que elementos interceptados pela trajetória sejam corretamente removidos.

# Impacto
Maior precisão durante o apagamento.
Eliminação de falhas causadas por movimentos rápidos do mouse.
