### PR TITLE
112 fix atalhos de teclado ausentes para ferramentas novas na sidebar

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -158,6 +158,7 @@ body {
   font-size: 18px;
   cursor: pointer;
   transition: background-color 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+  position: relative;
 }
 
 .btn-ferramenta:hover {
@@ -171,6 +172,30 @@ body {
   border-color: var(--cor-destaque);
   color: var(--cor-destaque);
   box-shadow: 0 0 0 2px rgba(74, 144, 217, 0.25);
+}
+
+.btn-ferramenta[data-tooltip]::after {
+  content: attr(data-tooltip);
+  position: absolute;
+  left: calc(100% + 10px);
+  top: 50%;
+  transform: translateY(-50%) translateX(-4px);
+  background-color: var(--cor-fundo-painel);
+  color: var(--cor-texto);
+  border: 1px solid var(--cor-destaque);
+  border-radius: var(--raio-borda);
+  padding: 4px 8px;
+  font-size: 12px;
+  white-space: nowrap;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.15s ease, transform 0.15s ease;
+  z-index: 100;
+}
+
+.btn-ferramenta[data-tooltip]:hover::after {
+  opacity: 1;
+  transform: translateY(-50%) translateX(0);
 }
 
 

--- a/index.html
+++ b/index.html
@@ -105,7 +105,7 @@
                         class="btn-ferramenta"
                         data-ferramenta="selecao"
                         data-nome="Seleção"
-                        title="Seleção (S)"
+                        data-tooltip="Seleção (S)"
                     >
                         &#9654;
                     </button>
@@ -113,7 +113,7 @@
                         class="btn-ferramenta"
                         data-ferramenta="edicaoVertices"
                         data-nome="Edição de Vértices"
-                        title="Edição por Vértices (E-V)"
+                        data-tooltip="Edição de Vértices (E-V)"
                     >
                         &#9688;
                     </button>
@@ -121,7 +121,7 @@
                         class="btn-ferramenta"
                         data-ferramenta="retangulo"
                         data-nome="Retângulo"
-                        title="Retângulo (R)"
+                        data-tooltip="Retângulo (R)"
                     >
                         &#9645;
                     </button>
@@ -129,7 +129,7 @@
                         class="btn-ferramenta"
                         data-ferramenta="elipse"
                         data-nome="Elipse"
-                        title="Elipse (E)"
+                        data-tooltip="Elipse (E)"
                     >
                         &#9711;
                     </button>
@@ -137,7 +137,7 @@
                         class="btn-ferramenta"
                         data-ferramenta="linha"
                         data-nome="Linha"
-                        title="Linha (L)"
+                        data-tooltip="Linha (L)"
                     >
                         &#9135;
                     </button>
@@ -145,7 +145,7 @@
                         class="btn-ferramenta"
                         data-ferramenta="poligono"
                         data-nome="Polígono / Polilinha"
-                        title="Polígono Polilinha (P)"
+                        data-tooltip="Polígono / Polilinha (P)"
                     >
                         &bowtie;
                     </button>
@@ -153,7 +153,7 @@
                         class="btn-ferramenta"
                         data-ferramenta="texto"
                         data-nome="Texto"
-                        title="Texto (T)"
+                        data-tooltip="Texto (T)"
                     >
                         T
                     </button>
@@ -161,7 +161,7 @@
                         class="btn-ferramenta"
                         data-ferramenta="Conta-gotas"
                         data-nome="Conta-gotas"
-                        title="Conta-gotas"
+                        data-tooltip="Conta-gotas"
                     >
                         <svg
                             xmlns="http://www.w3.org/2000/svg"
@@ -187,8 +187,8 @@
                     <button 
                         class="btn-ferramenta" 
                         data-ferramenta="borracha" 
-                        data-nome="Borracha" 
-                        title="Borracha (B)"
+                        data-nome="Borracha"
+                        data-tooltip="Borracha (B)"
                     >
                         <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
                         viewBox="0 0 24 24" fill="none"
@@ -201,8 +201,8 @@
                     <button 
                         class="btn-ferramenta" 
                         data-ferramenta="lapis" 
-                        data-nome="Lápis" 
-                        title="Lápis (P)"
+                        data-nome="Lápis"
+                        data-tooltip="Lápis"
                     >
                         &#128393;
                     </button>
@@ -212,7 +212,7 @@
                         class="btn-ferramenta" 
                         data-ferramenta="lupa" 
                         data-nome="Zoom"
-                        title="Zoom"
+                        data-tooltip="Zoom"
                     >
                         <svg xmlns="http://www.w3.org/2000/svg" width="22" height="22"
                           viewBox="0 0 24 24" fill="none"
@@ -231,7 +231,8 @@
                       <button
                         class="btn-ferramenta"
                         id="btn-importar-imagem"
-                        title="Importar Imagem (Raster)"
+                        data-nome="Importar Imagem"
+                        data-tooltip="Importar Imagem"
                     >
                         🖼️
                     </button>

--- a/index.html
+++ b/index.html
@@ -113,7 +113,7 @@
                         class="btn-ferramenta"
                         data-ferramenta="edicaoVertices"
                         data-nome="Edição de Vértices"
-                        data-tooltip="Edição de Vértices (E-V)"
+                        data-tooltip="Edição de Vértices (V)"
                     >
                         &#9688;
                     </button>
@@ -161,7 +161,7 @@
                         class="btn-ferramenta"
                         data-ferramenta="Conta-gotas"
                         data-nome="Conta-gotas"
-                        data-tooltip="Conta-gotas"
+                        data-tooltip="Conta-gotas (I)"
                     >
                         <svg
                             xmlns="http://www.w3.org/2000/svg"
@@ -202,7 +202,7 @@
                         class="btn-ferramenta" 
                         data-ferramenta="lapis" 
                         data-nome="Lápis"
-                        data-tooltip="Lápis"
+                        data-tooltip="Lápis (P)"
                     >
                         &#128393;
                     </button>
@@ -212,7 +212,7 @@
                         class="btn-ferramenta" 
                         data-ferramenta="lupa" 
                         data-nome="Zoom"
-                        data-tooltip="Zoom"
+                        data-tooltip="Zoom (Z)"
                     >
                         <svg xmlns="http://www.w3.org/2000/svg" width="22" height="22"
                           viewBox="0 0 24 24" fill="none"
@@ -232,7 +232,7 @@
                         class="btn-ferramenta"
                         id="btn-importar-imagem"
                         data-nome="Importar Imagem"
-                        data-tooltip="Importar Imagem"
+                        data-tooltip="Importar Imagem (Shift+I)"
                     >
                         🖼️
                     </button>

--- a/index.html
+++ b/index.html
@@ -54,7 +54,7 @@
 
                 <span id="ferramenta-atual-label"
                     >Ferramenta:
-                    <strong id="nome-ferramenta">Nenhuma</strong></span
+                    <strong id="nome-ferramenta">Nenhuma selecionada</strong></span
                 >
 
                 <!-- Controle de Camadas -->
@@ -104,6 +104,7 @@
                     <button
                         class="btn-ferramenta"
                         data-ferramenta="selecao"
+                        data-nome="Seleção"
                         title="Seleção (S)"
                     >
                         &#9654;
@@ -111,6 +112,7 @@
                     <button
                         class="btn-ferramenta"
                         data-ferramenta="edicaoVertices"
+                        data-nome="Edição de Vértices"
                         title="Edição por Vértices (E-V)"
                     >
                         &#9688;
@@ -118,6 +120,7 @@
                     <button
                         class="btn-ferramenta"
                         data-ferramenta="retangulo"
+                        data-nome="Retângulo"
                         title="Retângulo (R)"
                     >
                         &#9645;
@@ -125,6 +128,7 @@
                     <button
                         class="btn-ferramenta"
                         data-ferramenta="elipse"
+                        data-nome="Elipse"
                         title="Elipse (E)"
                     >
                         &#9711;
@@ -132,6 +136,7 @@
                     <button
                         class="btn-ferramenta"
                         data-ferramenta="linha"
+                        data-nome="Linha"
                         title="Linha (L)"
                     >
                         &#9135;
@@ -139,6 +144,7 @@
                     <button
                         class="btn-ferramenta"
                         data-ferramenta="poligono"
+                        data-nome="Polígono / Polilinha"
                         title="Polígono Polilinha (P)"
                     >
                         &bowtie;
@@ -146,6 +152,7 @@
                     <button
                         class="btn-ferramenta"
                         data-ferramenta="texto"
+                        data-nome="Texto"
                         title="Texto (T)"
                     >
                         T
@@ -153,6 +160,7 @@
                     <button
                         class="btn-ferramenta"
                         data-ferramenta="Conta-gotas"
+                        data-nome="Conta-gotas"
                         title="Conta-gotas"
                     >
                         <svg
@@ -176,7 +184,12 @@
                             <path d="m2 22 .414-.414" />
                         </svg>
                     </button>
-                    <button class="btn-ferramenta" data-ferramenta="borracha" title="Borracha (B)">
+                    <button 
+                        class="btn-ferramenta" 
+                        data-ferramenta="borracha" 
+                        data-nome="Borracha" 
+                        title="Borracha (B)"
+                    >
                         <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
                         viewBox="0 0 24 24" fill="none"
                         stroke="currentColor" stroke-width="2"
@@ -185,11 +198,22 @@
                         </svg>
                     </button>
 
-                    <button class="btn-ferramenta" data-ferramenta="lapis" title="Lápis (P)">
+                    <button 
+                        class="btn-ferramenta" 
+                        data-ferramenta="lapis" 
+                        data-nome="Lápis" 
+                        title="Lápis (P)"
+                    >
                         &#128393;
                     </button>
 
-                    <button id="btn-zoom-click" class="btn-ferramenta" data-ferramenta="lupa" title="Zoom padrão">
+                    <button 
+                        id="btn-zoom-click" 
+                        class="btn-ferramenta" 
+                        data-ferramenta="lupa" 
+                        data-nome="Zoom"
+                        title="Zoom"
+                    >
                         <svg xmlns="http://www.w3.org/2000/svg" width="22" height="22"
                           viewBox="0 0 24 24" fill="none"
                           stroke="currentColor" stroke-width="2"
@@ -203,7 +227,8 @@
                         </svg>
                       </button>
                       <div id="zoom-options" class="hidden"></div> <!-- Menu de opçoes para a lupa/zoom -->
-                    <button
+                    
+                      <button
                         class="btn-ferramenta"
                         id="btn-importar-imagem"
                         title="Importar Imagem (Raster)"

--- a/index.html
+++ b/index.html
@@ -145,7 +145,7 @@
                         class="btn-ferramenta"
                         data-ferramenta="poligono"
                         data-nome="Polígono / Polilinha"
-                        data-tooltip="Polígono / Polilinha (P)"
+                        data-tooltip="Polígono / Polilinha (G)"
                     >
                         &bowtie;
                     </button>

--- a/js/main.js
+++ b/js/main.js
@@ -106,14 +106,16 @@ const instanciasFerramentas = {
  * @param {string} nomeDaFerramenta - Identificador da ferramenta ativa.
  */
 function atualizarBotaoAtivo(nomeDaFerramenta) {
+  let nomeExibivel = 'Nenhuma selecionada';
   botoesFerramenta.forEach((btn) => {
     if (btn.getAttribute('data-ferramenta') === nomeDaFerramenta) {
       btn.classList.add('ativo');
+      nomeExibivel = btn.dataset.nome ?? btn.title ?? nomeDaFerramenta;
     } else {
       btn.classList.remove('ativo');
     }
   });
-  nomeFerramenta.textContent = nomeDaFerramenta || 'Nenhuma';
+  nomeFerramenta.textContent = nomeExibivel;
 }
 
 // --- Barra de Ferramentas & Modos ---

--- a/js/main.js
+++ b/js/main.js
@@ -225,9 +225,13 @@ window.addEventListener("keydown", (e) => {
     "r" : "retangulo",
     "e" : "elipse",
     "l" : "linha",
-    "p" : "poligono",
+    "g" : "poligono",
+    "p" : "lapis",
     "t" : "texto",
-    "i" : "conta-gotas"
+    "i" : "Conta-gotas",
+    "b" : "borracha",
+    "v" : "edicaoVertices",
+    "z" : "lupa",
   }
 
   const teclaPressionada = e.key.toLowerCase();

--- a/js/main.js
+++ b/js/main.js
@@ -219,7 +219,30 @@ window.addEventListener("keydown", (e) => {
 
   if (["input", "textarea", "select"].includes(tagAtiva) || elementoAtivo.isContentEditable)
     return;
-  
+
+  const teclaPressionada = e.key.toLowerCase();
+
+  // Atalhos com Shift
+  if (e.shiftKey) {
+    if (teclaPressionada === "z") {
+      e.preventDefault();
+      const btnDrag = document.getElementById('btn-drag');
+      if (btnDrag) {
+        btnDrag.click();
+      } else {
+        const botaoZoom = document.querySelector('.btn-ferramenta[data-ferramenta="lupa"]');
+        if (botaoZoom) {
+          botaoZoom.click();
+          setTimeout(() => document.getElementById('btn-drag')?.click(), 0);
+        }
+      }
+    } else if (teclaPressionada === "i") {
+      e.preventDefault();
+      btnImportarImagem?.click();
+    }
+    return;
+  }
+
   const mapaTeclas = {
     "s" : "selecao",
     "r" : "retangulo",
@@ -234,9 +257,8 @@ window.addEventListener("keydown", (e) => {
     "z" : "lupa",
   }
 
-  const teclaPressionada = e.key.toLowerCase();
   const ferramentaAlvo = mapaTeclas[teclaPressionada];
-  
+
   if (ferramentaAlvo) {
     e.preventDefault();
     const botao = document.querySelector(`.btn-ferramenta[data-ferramenta="${ferramentaAlvo}"]`);

--- a/js/tools/LupaTool.js
+++ b/js/tools/LupaTool.js
@@ -49,6 +49,10 @@ export class LupaTool extends ToolBase {
     const btnDrag = document.getElementById('btn-drag');
     if (!btnDrag) return;
     btnDrag.classList.toggle('ativo', this.modo === 'drag');
+
+    const nomeEl = document.getElementById('nome-ferramenta');
+    if (nomeEl) 
+      nomeEl.textContent = this.modo === 'drag' ? 'Zoom por Seleção' : 'Zoom';
   }
 
 

--- a/js/tools/LupaTool.js
+++ b/js/tools/LupaTool.js
@@ -75,7 +75,8 @@ export class LupaTool extends ToolBase {
     panel.innerHTML = `
       <button
         id="btn-drag"
-        title="Zoom por seleção">
+        class="btn-ferramenta"
+        data-tooltip="Zoom por Seleção (Shift+Z)">
 
         <svg 
           xmlns="http://www.w3.org/2000/svg"


### PR DESCRIPTION
## Descrição do que foi feito

- Corrigido bug: a chave "conta-gotas" no mapaTeclas não batia com o data-ferramenta="Conta-gotas" do HTML (C maiúsculo), fazendo o atalho I nunca funcionar
- Adicionados os atalhos ausentes para ferramentas novas da sidebar:

Tecla | Ferramenta
-- | --
B | Borracha
V | Edição de Vértices
G | Polígono / Polilinha (migrou de P)
P | Lápis (assumiu o P liberado pelo Polígono)
Z | Zoom
Shift+Z | Zoom por Seleção
Shift+I | Importar Imagem

@gustavoresque Acredito que tudo da issue foi implementado e que esteja pronto para merge. Único ponto de atenção é fazer o merge da #112 primeiro para evitar possíveis conflitos.