### PR TITLE
feat: Implementa o agrupar elementos.

### DIFF
--- a/js/core/GroupManager.js
+++ b/js/core/GroupManager.js
@@ -1,0 +1,96 @@
+import { estado, registrarAcaoHistorico } from './StateManager.js';
+import { criarElementoSVG } from '../utils/svgHelpers.js';
+
+/**
+ * Agrupa os elementos selecionados dentro de uma tag <g>
+ */
+export function agruparElementos() {
+    const elementos = estado.elementosSelecionados;
+    
+    // Só faz sentido agrupar se houver 2 ou mais elementos selecionados
+    if (!elementos || elementos.length < 2) return;
+
+    // 1. ORDENAR PELO Z-INDEX (Ordem no DOM)
+    // Isso garante que a sobreposição visual não quebre,
+    // não importa a ordem em que o usuário clicou nos elementos.
+    const elementosOrdenados = [...elementos].sort((a, b) => {
+        // Se 'a' vem antes de 'b' no DOM, a constante FOLLOWING é ativada
+        if (a.compareDocumentPosition(b) & Node.DOCUMENT_POSITION_FOLLOWING) {
+            return -1;
+        }
+        return 1;
+    });
+
+    // Cria o elemento de grupo <g>
+    const grupo = criarElementoSVG('g', {});
+    
+    // 2. DESCOBRIR ONDE INSERIR O GRUPO
+    // Pegamos o elemento que estava mais à frente (o último do array ordenado).
+    // Inserimos o grupo logo após ele para preservar o Z-Index global.
+    const elementoMaisAFrente = elementosOrdenados[elementosOrdenados.length - 1];
+    const pai = elementoMaisAFrente.parentNode;
+    pai.insertBefore(grupo, elementoMaisAFrente.nextSibling);
+
+    // 3. MOVER OS ELEMENTOS
+    // Como agora eles estão ordenados pelo DOM, o appendChild vai
+    // preservar perfeitamente a ordem interna entre eles.
+    elementosOrdenados.forEach(el => {
+        grupo.appendChild(el);
+    });
+
+    // Atualiza o estado da seleção: agora o grupo inteiro é o selecionado
+    estado.elementosSelecionados = [grupo];
+    
+    // Refaz o desenho da borda azul ao redor do novo grupo
+    if (estado.gerenciadorSelecao) {
+        estado.gerenciadorSelecao.desenhar(estado.elementosSelecionados);
+    }
+
+    // Registra a criação do grupo para o Ctrl+Z funcionar
+    registrarAcaoHistorico();
+}
+
+/**
+ * Desagrupa os elementos, removendo a tag <g> selecionada
+ */
+export function desagruparElementos() {
+    const elementos = estado.elementosSelecionados;
+    if (!elementos || elementos.length === 0) return;
+
+    let ocorreuDesagrupamento = false;
+    const novaSelecao = [];
+
+    elementos.forEach(el => {
+        // Verifica se o elemento selecionado é de fato um grupo
+        if (el.tagName.toLowerCase() === 'g') {
+            ocorreuDesagrupamento = true;
+            const pai = el.parentNode;
+            
+            // Pega todos os filhos de dentro do grupo
+            const filhos = Array.from(el.childNodes);
+            
+            // Move os filhos para fora do grupo (para o mesmo nível hierárquico do <g>)
+            filhos.forEach(filho => {
+                pai.insertBefore(filho, el);
+                novaSelecao.push(filho); // Adiciona os filhos soltos na nova seleção
+            });
+            
+            // Remove a tag <g> que agora ficou vazia
+            pai.removeChild(el);
+        } else {
+            // Se o usuário selecionou algo que não é um grupo, apenas mantém na seleção
+            novaSelecao.push(el);
+        }
+    });
+
+    // Se pelo menos um grupo foi desfeito, atualiza o estado e o histórico
+    if (ocorreuDesagrupamento) {
+        estado.elementosSelecionados = novaSelecao;
+        
+        if (estado.gerenciadorSelecao) {
+            estado.gerenciadorSelecao.desenhar(estado.elementosSelecionados);
+        }
+        
+        registrarAcaoHistorico();
+    }
+}

--- a/js/core/GroupManager.js
+++ b/js/core/GroupManager.js
@@ -107,6 +107,7 @@ export function desagruparElementos() {
     const novaSelecao = [];
 
     elementos.forEach(el => {
+        // Verifica se o elemento selecionado é de fato um grupo
         if (el.tagName.toLowerCase() === 'g') {
             ocorreuDesagrupamento = true;
             const pai = el.parentNode;
@@ -124,6 +125,7 @@ export function desagruparElementos() {
                 }
             }
             
+            // Pega todos os filhos de dentro do grupo
             const filhos = Array.from(el.childNodes);
             
             // 2. Move os filhos para fora aplicando o deslocamento
@@ -131,16 +133,17 @@ export function desagruparElementos() {
                 aplicarTranslacaoAoFilho(filho, grupoDx, grupoDy);
                 
                 pai.insertBefore(filho, el);
-                novaSelecao.push(filho); 
+                novaSelecao.push(filho); // Adiciona os filhos soltos na nova seleção
             });
             
             // 3. Remove a tag <g>
             pai.removeChild(el);
         } else {
-            novaSelecao.push(el);
+            novaSelecao.push(el); // Se o usuário selecionou algo que não é um grupo, apenas mantém na seleção
         }
     });
 
+    // Se pelo menos um grupo foi desfeito, atualiza o estado e o histórico
     if (ocorreuDesagrupamento) {
         estado.elementosSelecionados = novaSelecao;
         

--- a/js/core/GroupManager.js
+++ b/js/core/GroupManager.js
@@ -51,7 +51,53 @@ export function agruparElementos() {
 }
 
 /**
- * Desagrupa os elementos, removendo a tag <g> selecionada
+ * Aplica o deslocamento do grupo (dx, dy) diretamente nas coordenadas 
+ * do elemento filho para preservar sua posição visual.
+ */
+function aplicarTranslacaoAoFilho(el, dx, dy) {
+    if (dx === 0 && dy === 0) return;
+
+    const tag = el.tagName.toLowerCase();
+
+    // Repassa o valor diretamente para as propriedades primitivas
+    if (tag === 'rect' || tag === 'text' || tag === 'image') {
+        el.setAttribute('x', String(parseFloat(el.getAttribute('x') || 0) + dx));
+        el.setAttribute('y', String(parseFloat(el.getAttribute('y') || 0) + dy));
+    } else if (tag === 'circle' || tag === 'ellipse') {
+        el.setAttribute('cx', String(parseFloat(el.getAttribute('cx') || 0) + dx));
+        el.setAttribute('cy', String(parseFloat(el.getAttribute('cy') || 0) + dy));
+    } else if (tag === 'line') {
+        el.setAttribute('x1', String(parseFloat(el.getAttribute('x1') || 0) + dx));
+        el.setAttribute('y1', String(parseFloat(el.getAttribute('y1') || 0) + dy));
+        el.setAttribute('x2', String(parseFloat(el.getAttribute('x2') || 0) + dx));
+        el.setAttribute('y2', String(parseFloat(el.getAttribute('y2') || 0) + dy));
+    } else if (tag === 'path' || tag === 'g') {
+        // Para path e subgrupos, usamos a API nativa do SVG (igual na SelecaoTool)
+        const transformList = el.transform.baseVal;
+        let translateItem = null;
+
+        for (let i = 0; i < transformList.numberOfItems; i++) {
+            const item = transformList.getItem(i);
+            if (item.type === SVGTransform.SVG_TRANSFORM_TRANSLATE) {
+                translateItem = item;
+                break;
+            }
+        }
+
+        if (!translateItem) {
+            const svgRef = el.ownerSVGElement;
+            translateItem = svgRef.createSVGTransform();
+            translateItem.setTranslate(dx, dy);
+            transformList.appendItem(translateItem);
+        } else {
+            // Soma a translação existente com a translação do grupo pai
+            translateItem.setTranslate(translateItem.matrix.e + dx, translateItem.matrix.f + dy);
+        }
+    }
+}
+
+/**
+ * Desagrupa os elementos, repassando o deslocamento visual e removendo a tag <g>
  */
 export function desagruparElementos() {
     const elementos = estado.elementosSelecionados;
@@ -61,29 +107,40 @@ export function desagruparElementos() {
     const novaSelecao = [];
 
     elementos.forEach(el => {
-        // Verifica se o elemento selecionado é de fato um grupo
         if (el.tagName.toLowerCase() === 'g') {
             ocorreuDesagrupamento = true;
             const pai = el.parentNode;
             
-            // Pega todos os filhos de dentro do grupo
+            // 1. Descobre qual foi o deslocamento sofrido pelo grupo
+            let grupoDx = 0;
+            let grupoDy = 0;
+            const transformList = el.transform.baseVal;
+            for (let i = 0; i < transformList.numberOfItems; i++) {
+                const item = transformList.getItem(i);
+                if (item.type === SVGTransform.SVG_TRANSFORM_TRANSLATE) {
+                    grupoDx = item.matrix.e;
+                    grupoDy = item.matrix.f;
+                    break;
+                }
+            }
+            
             const filhos = Array.from(el.childNodes);
             
-            // Move os filhos para fora do grupo (para o mesmo nível hierárquico do <g>)
+            // 2. Move os filhos para fora aplicando o deslocamento
             filhos.forEach(filho => {
+                aplicarTranslacaoAoFilho(filho, grupoDx, grupoDy);
+                
                 pai.insertBefore(filho, el);
-                novaSelecao.push(filho); // Adiciona os filhos soltos na nova seleção
+                novaSelecao.push(filho); 
             });
             
-            // Remove a tag <g> que agora ficou vazia
+            // 3. Remove a tag <g>
             pai.removeChild(el);
         } else {
-            // Se o usuário selecionou algo que não é um grupo, apenas mantém na seleção
             novaSelecao.push(el);
         }
     });
 
-    // Se pelo menos um grupo foi desfeito, atualiza o estado e o histórico
     if (ocorreuDesagrupamento) {
         estado.elementosSelecionados = novaSelecao;
         

--- a/js/main.js
+++ b/js/main.js
@@ -34,6 +34,7 @@ import { inicializarImportadorImagem } from './tools/ImageImporter.js';
 import { inicializarMenuInicial } from './core/UIManager.js';
 import { PoligonoPolilinhaTool } from './tools/PoligonoPolilinhaTool.js';
 import { HistoryManager } from './core/HistoryManager.js';
+import { agruparElementos, desagruparElementos } from './core/GroupManager.js';
 
 const svgCanvas = document.getElementById('canvas');
 
@@ -295,6 +296,16 @@ window.addEventListener("keydown", (e) => {
   
   // Atalhos de teclado para o histórico
   if (e.ctrlKey || e.metaKey) { // metaKey é o Cmd do Mac
+    if (e.key.toLowerCase() === 'g') {
+      e.preventDefault(); // Impede o navegador de tentar buscar (find)
+      if (e.shiftKey) {
+        desagruparElementos();
+      } else {
+        agruparElementos();
+      }
+      atualizarBotoesHistorico(); // Sincroniza a interface de histórico
+      return;
+    }
     if (e.key.toLowerCase() === 'z') {
       e.preventDefault();
       if (e.shiftKey) {

--- a/js/tools/SelecaoTool.js
+++ b/js/tools/SelecaoTool.js
@@ -22,6 +22,48 @@ export class SelecaoTool extends ToolBase {
     this.estadoInicialMovimento = null;
   }
 
+  /**
+   * Lê a translação X e Y real do elemento nativamente
+   * @private
+   */
+  _obterTranslacao(el) {
+    const transformList = el.transform.baseVal;
+    for (let i = 0; i < transformList.numberOfItems; i++) {
+      const item = transformList.getItem(i);
+      if (item.type === SVGTransform.SVG_TRANSFORM_TRANSLATE) {
+        return { x: item.matrix.e, y: item.matrix.f };
+      }
+    }
+    return { x: 0, y: 0 };
+  }
+
+  /**
+   * Define a translação X e Y do elemento nativamente
+   * @private
+   */
+  _definirTranslacao(el, x, y) {
+    const transformList = el.transform.baseVal;
+    let translateItem = null;
+
+    for (let i = 0; i < transformList.numberOfItems; i++) {
+      const item = transformList.getItem(i);
+      if (item.type === SVGTransform.SVG_TRANSFORM_TRANSLATE) {
+        translateItem = item;
+        break;
+      }
+    }
+
+    // Se não existir, cria a propriedade Translate na matriz do elemento
+    if (!translateItem) {
+      const svgRef = el.ownerSVGElement || this.svgCanvas;
+      translateItem = svgRef.createSVGTransform();
+      translateItem.setTranslate(x, y);
+      transformList.appendItem(translateItem);
+    } else {
+      translateItem.setTranslate(x, y);
+    }
+  }
+
   onMouseDown(evento) {
     const pt = obterCoordenadaSVG(evento, this.svgCanvas);
     const target = evento.target;
@@ -89,11 +131,8 @@ export class SelecaoTool extends ToolBase {
           el.setAttribute('x2', String(parseFloat(el.getAttribute('x2') || 0) + dx));
           el.setAttribute('y2', String(parseFloat(el.getAttribute('y2') || 0) + dy));
       } else if (tag === 'path' || tag === 'g') {
-          //Usa a tranformação de translação, a mesma que foi vista em sala :), pra mover o objeto
-          el.setAttribute('transform', `translate(${novoX}, ${novoY})`);
-          // Guarda a posição atual para o próximo clique
-          el.setAttribute('data-x', String(novoX));
-          el.setAttribute('data-y', String(novoY));
+        // Aplica a translação nativa em vez de escrever string template
+        this._definirTranslacao(el, novoX, novoY);
       }
     });
 
@@ -164,6 +203,10 @@ export class SelecaoTool extends ToolBase {
       } else if (tag === 'line') {
         x = parseFloat(el.getAttribute('x1') || 0);
         y = parseFloat(el.getAttribute('y1') || 0);
+      } else if (tag === 'path' || tag === 'g') {
+        const translacao = this._obterTranslacao(el);
+        x = translacao.x;
+        y = translacao.y;
       }
       
       return { elemento: el, x, y, tag };
@@ -190,6 +233,10 @@ export class SelecaoTool extends ToolBase {
       } else if (tag === 'line') {
         xAtual = parseFloat(el.getAttribute('x1') || 0);
         yAtual = parseFloat(el.getAttribute('y1') || 0);
+      } else if (tag === 'path' || tag === 'g') {
+        const translacao = this._obterTranslacao(el);
+        xAtual = translacao.x;
+        yAtual = translacao.y;
       }
       
       if (xAtual !== estadoInicial.x || yAtual !== estadoInicial.y) {
@@ -204,16 +251,34 @@ export class SelecaoTool extends ToolBase {
    * @private
    */
   _buscarElementoValido(target, allowedTags) {
-    if (target === this.svgCanvas) return null;
+    if (target === this.svgCanvas || target.id === 'canvas') return null;
 
+    // Em vez de usar closest(), vamos subir na árvore e salvar o grupo mais ALTO (externo)
+    let grupoMaisExterno = null;
+    let atualBuscaGrupo = target;
+
+    while (atualBuscaGrupo && atualBuscaGrupo !== this.svgCanvas) {
+      if (atualBuscaGrupo.tagName && atualBuscaGrupo.tagName.toLowerCase() === 'g') {
+        grupoMaisExterno = atualBuscaGrupo; // Atualiza a variável toda vez que achar um <g>
+      }
+      atualBuscaGrupo = atualBuscaGrupo.parentNode;
+    }
+
+    // Se o elemento pertence a um ou mais grupos, seleciona o "Grupo Mestre" (o mais externo)
+    if (grupoMaisExterno) {
+      return grupoMaisExterno;
+    }
+
+    // Se não encontrou nenhum grupo, busca pela forma primitiva normal (rect, circle, etc)
     let atual = target;
     while (atual && atual !== this.svgCanvas) {
-      const tag = atual.tagName.toLowerCase();
+      const tag = atual.tagName ? atual.tagName.toLowerCase() : '';
       if (allowedTags.includes(tag)) {
         return atual;
       }
       atual = atual.parentNode;
     }
+    
     return null;
   }
 
@@ -235,8 +300,10 @@ export class SelecaoTool extends ToolBase {
         elX = parseFloat(el.getAttribute('x1') || 0);
         elY = parseFloat(el.getAttribute('y1') || 0);
       } else if (tag === 'path' || tag === 'g') {
-        elX = parseFloat(el.getAttribute('data-x') || 0);
-        elY = parseFloat(el.getAttribute('data-y') || 0);
+        // Usa a leitura nativa em vez do atributo 'data-x'
+        const translacao = this._obterTranslacao(el);
+        elX = translacao.x;
+        elY = translacao.y;
       }
 
       return { x: pontoMouse.x - elX, y: pontoMouse.y - elY };


### PR DESCRIPTION
O que foi alterado:
- Criação do GroupManager.js com as funções de agrupar e desagrupar elementos.
- Adição dos atalhos Ctrl+G (agrupar) e Ctrl+Shift+G (desagrupar) no main.js.
- Implementação de ordenação via compareDocumentPosition no agrupamento para manter a sobreposição visual original (z-index).
- Atualização da SelecaoTool.js para selecionar grupos aninhados, buscando sempre a tag <g> mais externa.
- Refatoração na movimentação de <g> e <path> na SelecaoTool.js: remoção do uso de strings/data-attributes em favor da API nativa e robusta SVGTransformList.
- Correção do registro de histórico (Ctrl+Z) para refletir transformações de grupos e paths.

Como usar:
- Agrupar: Selecione múltiplos elementos na tela e pressione Ctrl + G (ou Cmd + G no Mac).
- Desagrupar: Selecione um grupo e pressione Ctrl + Shift + G.