### PR TITLE
feat: integrar polilinha ao histórico de Undo/Redo

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -14,7 +14,6 @@ import {
   definirCorBorda, 
   definirGerenciadorSelecao,
   definirElementosSelecionados,
-  definirGerenciadorSelecao,
   definirGerenciadorHistorico,
   desfazerAcao,
   refazerAcao,

--- a/js/tools/PoligonoPolilinhaTool.js
+++ b/js/tools/PoligonoPolilinhaTool.js
@@ -139,7 +139,7 @@ export class PoligonoPolilinhaTool extends ToolBase {
         });
 
         this.svgCanvas.appendChild(poligonoFinal);
-
+        registrarAcaoHistorico();
         // Limpa o estado interno para o próximo desenho
         this.polylineElement = null;
         this.vertices = [];

--- a/js/tools/PoligonoPolilinhaTool.js
+++ b/js/tools/PoligonoPolilinhaTool.js
@@ -1,6 +1,7 @@
 import { ToolBase } from "./ToolBase.js";
 import { criarElementoSVG, obterCoordenadaSVG } from '../utils/svgHelpers.js';
 import { estado } from '../core/StateManager.js';
+import { registrarAcaoHistorico } from '../core/StateManager.js';
 
 export class PoligonoPolilinhaTool extends ToolBase {
     constructor(svgCanvas) {


### PR DESCRIPTION
## Descrição

Este PR adiciona o registro da criação de polígonos/polilinhas no histórico da aplicação, permitindo que as operações de **Undo** e **Redo** funcionem corretamente para essa ferramenta.

### Alterações

* Adicionada a chamada de `registrarAcaoHistorico()` ao finalizar a criação de um polígono.
* Adicionada a importação da função `registrarAcaoHistorico`.

### Critérios de aceite

* [x] A criação do polígono é registrada no histórico ao ser finalizada.
* [x] O Undo desfaz apenas o último polígono criado.
* [x] O Redo restaura o último polígono desfeito.

@gustavoresque 
