### PR TITLE
140 feature adicionar seleção do elemento polilinha

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -14,7 +14,6 @@ import {
   definirCorBorda, 
   definirGerenciadorSelecao,
   definirElementosSelecionados,
-  definirGerenciadorSelecao,
   definirGerenciadorHistorico,
   desfazerAcao,
   refazerAcao,

--- a/js/tools/SelecaoTool.js
+++ b/js/tools/SelecaoTool.js
@@ -27,7 +27,7 @@ export class SelecaoTool extends ToolBase {
     const target = evento.target;
     const isShift = evento.shiftKey;
 
-    const allowedTags = ['rect', 'text', 'image', 'circle', 'ellipse', 'g', 'path', 'line', 'lapis'];
+    const allowedTags = ['rect', 'text', 'image', 'circle', 'ellipse', 'g', 'path', 'line', 'lapis', 'polygon'];
     const tag = target.tagName ? target.tagName.toLowerCase() : '';
 
     // Verifica se o clique foi em um elemento válido dentro do canvas
@@ -88,7 +88,7 @@ export class SelecaoTool extends ToolBase {
           el.setAttribute('y1', String(novoY));
           el.setAttribute('x2', String(parseFloat(el.getAttribute('x2') || 0) + dx));
           el.setAttribute('y2', String(parseFloat(el.getAttribute('y2') || 0) + dy));
-      } else if (tag === 'path' || tag === 'g') {
+      } else if (tag === 'path' || tag === 'g' || tag == 'polygon') {
           //Usa a tranformação de translação, a mesma que foi vista em sala :), pra mover o objeto
           el.setAttribute('transform', `translate(${novoX}, ${novoY})`);
           // Guarda a posição atual para o próximo clique
@@ -164,6 +164,9 @@ export class SelecaoTool extends ToolBase {
       } else if (tag === 'line') {
         x = parseFloat(el.getAttribute('x1') || 0);
         y = parseFloat(el.getAttribute('y1') || 0);
+      }else if (tag === 'path' || tag === 'g' || tag === 'polygon') {
+        x = parseFloat(el.getAttribute('data-x') || 0);
+        y = parseFloat(el.getAttribute('data-y') || 0);
       }
       
       return { elemento: el, x, y, tag };
@@ -234,7 +237,7 @@ export class SelecaoTool extends ToolBase {
       } else if (tag === 'line') {
         elX = parseFloat(el.getAttribute('x1') || 0);
         elY = parseFloat(el.getAttribute('y1') || 0);
-      } else if (tag === 'path' || tag === 'g') {
+      } else if (tag === 'path' || tag === 'g' || tag == 'polygon') {
         elX = parseFloat(el.getAttribute('data-x') || 0);
         elY = parseFloat(el.getAttribute('data-y') || 0);
       }


### PR DESCRIPTION
## Descrição

Esta PR adiciona suporte à seleção de polilinhas pela ferramenta de seleção. Para isso, o elemento `polygon` foi incluído entre os tipos de elementos selecionáveis e passou a ser tratado pela lógica de movimentação da `SelecaoTool`.

Com essa alteração, polilinhas podem ser selecionadas e movimentadas da mesma forma que os demais elementos suportados pelo editor, atendendo aos critérios definidos na issue.

## Alterações realizadas

* Adicionado suporte ao elemento `polygon` na validação de elementos selecionáveis;
* Implementado o tratamento de `polygon` na lógica de movimentação da ferramenta de seleção;
* Atualizada a manipulação de posição e cálculo de deslocamento para permitir a interação com polilinhas.

## Resultado

* É possível selecionar uma polilinha utilizando a ferramenta de seleção;
* É possível mover a polilinha selecionada normalmente.


@gustavoresque 