### PR TITLE
feat: Adicionar a logica de undo/redo a ferramenta Lapis

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -14,7 +14,6 @@ import {
   definirCorBorda, 
   definirGerenciadorSelecao,
   definirElementosSelecionados,
-  definirGerenciadorSelecao,
   definirGerenciadorHistorico,
   desfazerAcao,
   refazerAcao,

--- a/js/tools/LapisTool.js
+++ b/js/tools/LapisTool.js
@@ -28,7 +28,9 @@ export class Lapis extends ToolBase {
             "stroke-width": 2,
             fill: "none",
             "stroke-linecap": "round",
-            "stroke-linejoin": "round"
+            "stroke-linejoin": "round",
+            "data-x": "0",
+            "data-y": "0"
         });
     
         this.svgCanvas.appendChild(this.path);

--- a/js/tools/LapisTool.js
+++ b/js/tools/LapisTool.js
@@ -1,6 +1,7 @@
 import { ToolBase } from './ToolBase.js';
 import { criarElementoSVG, obterCoordenadaSVG } from '../utils/svgHelpers.js';
 import { estado } from '../core/StateManager.js';
+import { registrarAcaoHistorico } from '../core/StateManager.js';
 
 export class Lapis extends ToolBase {
     constructor(svgCanvas){
@@ -59,5 +60,7 @@ export class Lapis extends ToolBase {
         this.d = "";
         this.ultimoPonto = null;
         this.penultimoPonto = null;
+
+        registrarAcaoHistorico();
     }
 }

--- a/js/tools/SelecaoTool.js
+++ b/js/tools/SelecaoTool.js
@@ -164,6 +164,9 @@ export class SelecaoTool extends ToolBase {
       } else if (tag === 'line') {
         x = parseFloat(el.getAttribute('x1') || 0);
         y = parseFloat(el.getAttribute('y1') || 0);
+      } else if (tag === 'path' || tag === 'g') {
+        x = parseFloat(el.getAttribute('data-x') || 0);
+        y = parseFloat(el.getAttribute('data-y') || 0);
       }
       
       return { elemento: el, x, y, tag };
@@ -190,6 +193,9 @@ export class SelecaoTool extends ToolBase {
       } else if (tag === 'line') {
         xAtual = parseFloat(el.getAttribute('x1') || 0);
         yAtual = parseFloat(el.getAttribute('y1') || 0);
+      } else if (tag === 'path' || tag === 'g') {
+        xAtual = parseFloat(el.getAttribute('data-x') || 0);
+        yAtual = parseFloat(el.getAttribute('data-y') || 0);
       }
       
       if (xAtual !== estadoInicial.x || yAtual !== estadoInicial.y) {


### PR DESCRIPTION
## Descrição

Esta PR implementa o suporte ao mecanismo de Undo/Redo na ferramenta Lápis, integrando-a ao sistema de histórico da aplicação.
Agora, ao finalizar um desenho com a ferramenta Lápis, o estado do canvas é registrado, permitindo desfazer e refazer a última ação corretamente.

## Alterações
- Integração da ferramenta Lápis ao HistoryManager;
- Registro da ação no histórico ao finalizar um desenho;

@gustavoresque 