### PR TITLE
124 [UX/UI] Agrupamento de ferramentas por categoria na sidebar

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -606,3 +606,52 @@ body {
     fill: #4a90d9; /* Inverte a cor ao passar o mouse */
     stroke: white;
 }
+
+
+
+/* =========================================================
+   Grupos de Ferramentas da Sidebar
+   ========================================================= */
+
+.btn-grupo {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  background-color: transparent;
+  color: var(--cor-texto);
+  border: 1px solid var(--cor-borda-ui);
+  border-radius: var(--raio-borda);
+  font-size: 18px;
+  cursor: pointer;
+  transition: background-color 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+}
+
+.btn-grupo:hover {
+  background-color: rgba(74, 144, 217, 0.2);
+  border-color: var(--cor-destaque);
+  color: var(--cor-destaque);
+}
+
+.btn-grupo.ativo {
+  background-color: rgba(74, 144, 217, 0.35);
+  border-color: var(--cor-destaque);
+  color: var(--cor-destaque);
+  box-shadow: 0 0 0 2px rgba(74, 144, 217, 0.25);
+}
+
+.grupo-ferramentas {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 4px 0;
+  border-left: 2px solid var(--cor-destaque);
+  margin-left: 4px;
+}
+
+.grupo-ferramentas.escondido {
+  display: none;
+}

--- a/css/style.css
+++ b/css/style.css
@@ -250,6 +250,30 @@ body {
   transform: translateY(-50%) translateX(0);
 }
 
+.btn-grupo[data-tooltip]::after {
+  content: attr(data-tooltip);
+  position: absolute;
+  left: calc(100% + 10px);
+  top: 50%;
+  transform: translateY(-50%) translateX(-4px);
+  background-color: var(--cor-fundo-painel);
+  color: var(--cor-texto);
+  border: 1px solid var(--cor-destaque);
+  border-radius: var(--raio-borda);
+  padding: 4px 8px;
+  font-size: 12px;
+  white-space: nowrap;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.15s ease, transform 0.15s ease;
+  z-index: 100;
+}
+
+.btn-grupo[data-tooltip]:hover::after {
+  opacity: 1;
+  transform: translateY(-50%) translateX(0);
+}
+
 
 /* =========================================================
    Área Exportação
@@ -626,6 +650,7 @@ body {
   font-size: 18px;
   cursor: pointer;
   transition: background-color 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+  position: relative;
 }
 
 .btn-grupo:hover {

--- a/index.html
+++ b/index.html
@@ -99,187 +99,185 @@
             <div id="workspace">
                 <!-- Barra Lateral: botões das ferramentas de desenho -->
                 <aside id="barra-ferramentas">
-                    <button
-                        id="btn-selecionar"
-                        class="btn-ferramenta"
-                        data-ferramenta="selecao"
-                        data-nome="Seleção"
-                        data-tooltip="Seleção (S)"
-                    >
+
+                    <!-- GRUPO: Seleção -->
+                    <button class="btn-grupo" data-grupo="selecao" title="Seleção">
                         &#9654;
                     </button>
-                    <button
-                        id="btn-edicao-vertices"
-                        class="btn-ferramenta"
-                        data-ferramenta="edicaoVertices"
-                        data-nome="Edição de Vértices"
-                        data-tooltip="Edição de Vértices (V)"
-                    >
-                        &#9688;
-                    </button>
-                    <button
-                        id="btn-criar-retangulo"
-                        class="btn-ferramenta"
-                        data-ferramenta="retangulo"
-                        data-nome="Retângulo"
-                        data-tooltip="Retângulo (R)"
-                    >
+                    <div class="grupo-ferramentas escondido" id="grupo-selecao">
+                        <button
+                            id="btn-selecionar"
+                            class="btn-ferramenta"
+                            data-ferramenta="selecao"
+                            data-nome="Seleção"
+                            data-tooltip="Seleção (S)"
+                        >
+                            &#9654;
+                        </button>
+                        <button
+                            id="btn-edicao-vertices"
+                            class="btn-ferramenta"
+                            data-ferramenta="edicaoVertices"
+                            data-nome="Edição de Vértices"
+                            data-tooltip="Edição de Vértices (V)"
+                        >
+                            &#9688;
+                        </button>
+                    </div>
+
+                    <!-- GRUPO: Formas -->
+                    <button class="btn-grupo" data-grupo="formas" title="Formas">
                         &#9645;
                     </button>
-                    <button
-                        id="btn-criar-elipse"
-                        class="btn-ferramenta"
-                        data-ferramenta="elipse"
-                        data-nome="Elipse"
-                        data-tooltip="Elipse (E)"
-                    >
-                        &#9711;
-                    </button>
-                    <button
-                        id="btn-criar-linha"
-                        class="btn-ferramenta"
-                        data-ferramenta="linha"
-                        data-nome="Linha"
-                        data-tooltip="Linha (L)"
-                    >
-                        &#9135;
-                    </button>
-                    <button
-                        id="btn-criar-linha-curvada"
-                        class="btn-ferramenta"
-                        data-ferramenta="linhaCurvada"
-                        data-nome="Linha Curvada"
-                        data-tooltip="Linha Curvada (C)"
-                    >
-                        <svg
-                            xmlns="http://www.w3.org/2000/svg"
-                            width="24"
-                            height="24"
-                            viewBox="0 0 24 24"
-                            fill="none"
-                            stroke="currentColor"
-                            stroke-width="2"
-                            stroke-linecap="round"
-                            stroke-linejoin="round"
-                            aria-hidden="true"
-                            focusable="false"
+                    <div class="grupo-ferramentas escondido" id="grupo-formas">
+                        <button
+                            id="btn-criar-retangulo"
+                            class="btn-ferramenta"
+                            data-ferramenta="retangulo"
+                            data-nome="Retângulo"
+                            data-tooltip="Retângulo (R)"
                         >
-                            <path d="M4 18C8 4 16 4 20 18" />
-                        </svg>
-                    </button>
-                    <button
-                        id="btn-criar-polilinha"
-                        class="btn-ferramenta"
-                        data-ferramenta="poligono"
-                        data-nome="Polígono / Polilinha"
-                        data-tooltip="Polígono / Polilinha (G)"
-                    >
-                        &bowtie;
-                    </button>
-                    <button
-                        id="btn-criar-texto"
-                        class="btn-ferramenta"
-                        data-ferramenta="texto"
-                        data-nome="Texto"
-                        data-tooltip="Texto (T)"
-                    >
-                        T
-                    </button>
-                    <button
-                        id="btn-pintar"
-                        class="btn-ferramenta"
-                        data-ferramenta="Conta-gotas"
-                        data-nome="Conta-gotas"
-                        data-tooltip="Conta-gotas (I)"
-                    >
-                        <svg
-                            xmlns="http://www.w3.org/2000/svg"
-                            width="24"
-                            height="24"
-                            viewBox="0 0 24 24"
-                            fill="none"
-                            stroke="currentColor"
-                            stroke-width="2"
-                            stroke-linecap="round"
-                            stroke-linejoin="round"
-                            class="lucide lucide-pipette-icon lucide-pipette"
+                            &#9645;
+                        </button>
+                        <button
+                            id="btn-criar-elipse"
+                            class="btn-ferramenta"
+                            data-ferramenta="elipse"
+                            data-nome="Elipse"
+                            data-tooltip="Elipse (E)"
                         >
-                            <path
-                                d="m12 9-8.414 8.414A2 2 0 0 0 3 18.828v1.344a2 2 0 0 1-.586 1.414A2 2 0 0 1 3.828 21h1.344a2 2 0 0 0 1.414-.586L15 12"
-                            />
-                            <path
-                                d="m18 9 .4.4a1 1 0 1 1-3 3l-3.8-3.8a1 1 0 1 1 3-3l.4.4 3.4-3.4a1 1 0 1 1 3 3z"
-                            />
-                            <path d="m2 22 .414-.414" />
-                        </svg>
-                    </button>
-                    <button 
-                        id="btn-borracha"
-                        class="btn-ferramenta" 
-                        data-ferramenta="borracha" 
-                        data-nome="Borracha"
-                        data-tooltip="Borracha (B)"
-                    >
-                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
-                        viewBox="0 0 24 24" fill="none"
-                        stroke="currentColor" stroke-width="2"
-                        stroke-linecap="round" stroke-linejoin="round">
-                        <path d="M20 20H7L3 16L14 5L21 12L13 20"/>
-                        </svg>
-                    </button>
+                            &#9711;
+                        </button>
+                        <button
+                            id="btn-criar-linha"
+                            class="btn-ferramenta"
+                            data-ferramenta="linha"
+                            data-nome="Linha"
+                            data-tooltip="Linha (L)"
+                        >
+                            &#9135;
+                        </button>
+                        <button
+                            id="btn-criar-linha-curvada"
+                            class="btn-ferramenta"
+                            data-ferramenta="linhaCurvada"
+                            data-nome="Linha Curvada"
+                            data-tooltip="Linha Curvada (C)"
+                        >
+                            <svg
+                                xmlns="http://www.w3.org/2000/svg"
+                                width="24"
+                                height="24"
+                                viewBox="0 0 24 24"
+                                fill="none"
+                                stroke="currentColor"
+                                stroke-width="2"
+                                stroke-linecap="round"
+                                stroke-linejoin="round"
+                                aria-hidden="true"
+                                focusable="false"
+                            >
+                                <path d="M4 18C8 4 16 4 20 18" />
+                            </svg>
+                        </button>
+                        <button
+                            id="btn-criar-polilinha"
+                            class="btn-ferramenta"
+                            data-ferramenta="poligono"
+                            data-nome="Polígono / Polilinha"
+                            data-tooltip="Polígono / Polilinha (G)"
+                        >
+                            &bowtie;
+                        </button>
+                    </div>
 
-                    <button 
-                        id="btn-lapis"
-                        class="btn-ferramenta" 
-                        data-ferramenta="lapis" 
-                        data-nome="Lápis"
-                        data-tooltip="Lápis (P)"
-                    >
+                    <!-- GRUPO: Desenho -->
+                    <button class="btn-grupo" data-grupo="desenho" title="Desenho">
                         &#128393;
                     </button>
+                    <div class="grupo-ferramentas escondido" id="grupo-desenho">
+                        <button
+                            id="btn-lapis"
+                            class="btn-ferramenta"
+                            data-ferramenta="lapis"
+                            data-nome="Lápis"
+                            data-tooltip="Lápis (P)"
+                        >
+                            &#128393;
+                        </button>
+                        <button
+                            id="btn-pincel"
+                            class="btn-ferramenta"
+                            data-ferramenta="pincel"
+                            data-nome="Pincel"
+                            data-tooltip="Pincel dinâmico"
+                        >
+                            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round" stroke-linecap="round">
+                                <line x1="18" y1="2" x2="9" y2="11"/>
+                                <path d="M6 14 L9 11 L13 15 L10 18 Z"/>
+                                <path d="M10 18 Q8 21 6 22 Q7 20 6 14"/>
+                            </svg>
+                        </button>
+                        <button
+                            id="btn-borracha"
+                            class="btn-ferramenta"
+                            data-ferramenta="borracha"
+                            data-nome="Borracha"
+                            data-tooltip="Borracha (B)"
+                        >
+                            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                                <path d="M20 20H7L3 16L14 5L21 12L13 20"/>
+                            </svg>
+                        </button>
+                    </div>
 
-                    <button
-                        id="btn-pincel"
-                        class="btn-ferramenta"
-                        data-ferramenta="pincel"
-                        data-nome="Pincel"
-                        data-tooltip="Pincel dinâmico"
-                    >
-                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round" stroke-linecap="round">
-                            <line x1="18" y1="2" x2="9" y2="11"/>
-                            <path d="M6 14 L9 11 L13 15 L10 18 Z"/>
-                            <path d="M10 18 Q8 21 6 22 Q7 20 6 14"/>
-                        </svg>
+                    <!-- GRUPO: Utilitários -->
+                    <button class="btn-grupo" data-grupo="utilitarios" title="Utilitários">
+                        T
                     </button>
+                    <div class="grupo-ferramentas escondido" id="grupo-utilitarios">
+                        <button
+                            id="btn-criar-texto"
+                            class="btn-ferramenta"
+                            data-ferramenta="texto"
+                            data-nome="Texto"
+                            data-tooltip="Texto (T)"
+                        >
+                            T
+                        </button>
+                        <button
+                            id="btn-pintar"
+                            class="btn-ferramenta"
+                            data-ferramenta="Conta-gotas"
+                            data-nome="Conta-gotas"
+                            data-tooltip="Conta-gotas (I)"
+                        >
+                            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-pipette-icon lucide-pipette">
+                                <path d="m12 9-8.414 8.414A2 2 0 0 0 3 18.828v1.344a2 2 0 0 1-.586 1.414A2 2 0 0 1 3.828 21h1.344a2 2 0 0 0 1.414-.586L15 12"/>
+                                <path d="m18 9 .4.4a1 1 0 1 1-3 3l-3.8-3.8a1 1 0 1 1 3-3l.4.4 3.4-3.4a1 1 0 1 1 3 3z"/>
+                                <path d="m2 22 .414-.414"/>
+                            </svg>
+                        </button>
+                        <button
+                            id="btn-zoom-click"
+                            class="btn-ferramenta"
+                            data-ferramenta="lupa"
+                            data-nome="Zoom"
+                            data-tooltip="Zoom (Z)"
+                        >
+                            <svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                                <circle cx="11" cy="11" r="7"></circle>
+                                <line x1="21" y1="21" x2="16.65" y2="16.65"></line>
+                            </svg>
+                        </button>
+                        <div id="zoom-options" class="hidden"></div>
+                        <button class="btn-ferramenta" id="btn-importar-imagem" data-nome="Importar Imagem" data-tooltip="Importar Imagem (Shift+I)">
+                            🖼️
+                        </button>
+                        <input type="file" id="input-imagem" accept="image/png, image/jpeg, image/svg+xml" style="display: none;" />
+                    </div>
 
-                    <button 
-                        id="btn-zoom-click" 
-                        class="btn-ferramenta" 
-                        data-ferramenta="lupa" 
-                        data-nome="Zoom"
-                        data-tooltip="Zoom (Z)"
-                    >
-                        <svg xmlns="http://www.w3.org/2000/svg" width="22" height="22"
-                          viewBox="0 0 24 24" fill="none"
-                          stroke="currentColor" stroke-width="2"
-                          stroke-linecap="round" stroke-linejoin="round">
-
-                        <!-- lente -->
-                        <circle cx="11" cy="11" r="7"></circle>
-                        <!-- cabo -->
-                        <line x1="21" y1="21" x2="16.65" y2="16.65"></line>
-
-                    </svg>
-                </button>
-                <div id="zoom-options" class="hidden"></div> <!-- Menu de opçoes para a lupa/zoom -->
-                    
-                <button class="btn-ferramenta" id="btn-importar-imagem" data-nome="Importar Imagem"
-                        data-tooltip="Importar Imagem (Shift+I)">
-                    🖼️
-                </button>
-
-                <input type="file" id="input-imagem" accept="image/png, image/jpeg, image/svg+xml" style="display: none;" />
-            </aside>
+                </aside>
 
             <!-- Área Central de Desenho -->
             <main id="area-desenho">

--- a/index.html
+++ b/index.html
@@ -101,7 +101,7 @@
                 <aside id="barra-ferramentas">
 
                     <!-- GRUPO: Seleção -->
-                    <button class="btn-grupo" data-grupo="selecao" title="Seleção">
+                    <button class="btn-grupo" data-grupo="selecao" data-tooltip="Seleção">
                         &#9654;
                     </button>
                     <div class="grupo-ferramentas escondido" id="grupo-selecao">
@@ -126,7 +126,7 @@
                     </div>
 
                     <!-- GRUPO: Formas -->
-                    <button class="btn-grupo" data-grupo="formas" title="Formas">
+                    <button class="btn-grupo" data-grupo="formas" data-tooltip="Formas">
                         &#9645;
                     </button>
                     <div class="grupo-ferramentas escondido" id="grupo-formas">
@@ -192,7 +192,7 @@
                     </div>
 
                     <!-- GRUPO: Desenho -->
-                    <button class="btn-grupo" data-grupo="desenho" title="Desenho">
+                    <button class="btn-grupo" data-grupo="desenho" data-tooltip="Desenho">
                         &#128393;
                     </button>
                     <div class="grupo-ferramentas escondido" id="grupo-desenho">
@@ -232,7 +232,7 @@
                     </div>
 
                     <!-- GRUPO: Utilitários -->
-                    <button class="btn-grupo" data-grupo="utilitarios" title="Utilitários">
+                    <button class="btn-grupo" data-grupo="utilitarios" data-tooltip="Utilitários">
                         T
                     </button>
                     <div class="grupo-ferramentas escondido" id="grupo-utilitarios">

--- a/js/core/ToolbarGroup.js
+++ b/js/core/ToolbarGroup.js
@@ -1,0 +1,46 @@
+/**
+ * ToolbarGroup.js — Gerencia os grupos de ferramentas da sidebar
+ *
+ * Responsabilidades:
+ * - Abrir e fechar grupos ao clicar nos botões de grupo (btn-grupo)
+ * - Garantir que apenas um grupo fique aberto por vez
+ * - Marcar o btn-grupo como ativo quando seu grupo estiver aberto
+ */
+
+export class ToolbarGroup {
+  constructor() {
+    this.botoesGrupo = document.querySelectorAll('.btn-grupo');
+    this.grupos = document.querySelectorAll('.grupo-ferramentas');
+    this.grupoAtivo = null;
+    this.init();
+  }
+
+  init() {
+    this.botoesGrupo.forEach((btn) => {
+      btn.addEventListener('click', () => {
+        const idGrupo = `grupo-${btn.getAttribute('data-grupo')}`;
+        this.toggleGrupo(idGrupo, btn);
+      });
+    });
+  }
+
+  toggleGrupo(idGrupo, btnClicado) {
+    const grupoAlvo = document.getElementById(idGrupo);
+    if (!grupoAlvo) return;
+
+    const estaAberto = !grupoAlvo.classList.contains('escondido');
+
+    // Fecha todos os grupos e remove ativo de todos os botões
+    this.grupos.forEach((g) => g.classList.add('escondido'));
+    this.botoesGrupo.forEach((b) => b.classList.remove('ativo'));
+
+    // Se o grupo clicado estava fechado, abre ele
+    if (!estaAberto) {
+      grupoAlvo.classList.remove('escondido');
+      btnClicado.classList.add('ativo');
+      this.grupoAtivo = idGrupo;
+    } else {
+      this.grupoAtivo = null;
+    }
+  }
+}

--- a/js/main.js
+++ b/js/main.js
@@ -42,6 +42,7 @@ import { CameraSVG } from './core/CameraSVG.js';
 import { obterCoordenadaSVG } from './utils/svgHelpers.js';
 import { HistoryManager } from './core/HistoryManager.js';
 import { agruparElementos, desagruparElementos } from './core/GroupManager.js';
+import { ToolbarGroup } from './core/ToolbarGroup.js';
 
 const svgCanvas = document.getElementById('canvas');
 
@@ -54,6 +55,7 @@ inicializarMenuInicial(svgCanvas);
 
 // Inicializar a sidebar
 const barraLateral = new SideBar();
+const toolbarGroup = new ToolbarGroup();
 
 const areaDesenho = document.getElementById('area-desenho');
 const botoesFerramenta = document.querySelectorAll('.btn-ferramenta');


### PR DESCRIPTION
## O que foi implementado

Agrupa as ferramentas da sidebar esquerda em categorias, permitindo que o usuário clique em um grupo para expandir suas ferramentas.

## Grupos criados

| Grupo | Ferramentas |
|-------|------------|
| Seleção | Seleção, Edição de Vértices |
| Formas | Retângulo, Elipse, Linha, Linha Curvada, Polígono |
| Desenho | Lápis, Pincel, Borracha |
| Utilitários | Texto, Conta-gotas, Zoom, Importar Imagem |

## Arquivos modificados

- `index.html` — reorganização dos botões em grupos
- `css/style.css` — estilos para grupos e tooltips
- `js/core/ToolbarGroup.js` — lógica de abrir/fechar grupos
- `js/main.js` — inicialização do ToolbarGroup

## Commits

- `feat(html)`: reorganiza sidebar em grupos de ferramentas por categoria
- `feat(css)`: adiciona estilos para grupos de ferramentas da sidebar
- `feat(js)`: cria ToolbarGroup para gerenciar abertura e fechamento de grupos
- `feat(js)`: integra ToolbarGroup no main.js
- `fix(css,html)`: padroniza tooltip dos botões de grupo com data-tooltip

Closes #124

@gustavoresque