### PR TITLE
Feature/unificação ferramenta seleção edição

### DIFF
--- a/index.html
+++ b/index.html
@@ -109,6 +109,15 @@
                         &#9654;
                     </button>
                     <button
+                        id="btn-edicao-vertices"
+                        class="btn-ferramenta"
+                        data-ferramenta="edicaoVertices"
+                        data-nome="Edição de Vértices"
+                        data-tooltip="Edição de Vértices (V)"
+                    >
+                        &#9688;
+                    </button>
+                    <button
                         id="btn-criar-retangulo"
                         class="btn-ferramenta"
                         data-ferramenta="retangulo"

--- a/index.html
+++ b/index.html
@@ -109,15 +109,6 @@
                         &#9654;
                     </button>
                     <button
-                        id="btn-edicao-vertices"
-                        class="btn-ferramenta"
-                        data-ferramenta="edicaoVertices"
-                        data-nome="Edição de Vértices"
-                        data-tooltip="Edição de Vértices (V)"
-                    >
-                        &#9688;
-                    </button>
-                    <button
                         id="btn-criar-retangulo"
                         class="btn-ferramenta"
                         data-ferramenta="retangulo"

--- a/js/core/StateManager.js
+++ b/js/core/StateManager.js
@@ -33,6 +33,18 @@ export function atualizarPosicaoSelecaoVisual() {
   }
 }
 
+export function ocultarSelecaoVisual() {
+  if (gerenciadorSelecaoVisual) {
+    gerenciadorSelecaoVisual.limpar();
+  }
+}
+
+export function redesenharSelecaoVisual() {
+  if (gerenciadorSelecaoVisual && estado.elementosSelecionados.length > 0) {
+    gerenciadorSelecaoVisual.desenhar(estado.elementosSelecionados);
+  }
+}
+
 /**
  * Define a ferramenta de desenho ativa.
  * Invoca os métodos de ciclo de vida `onDesativar` na ferramenta anterior

--- a/js/main.js
+++ b/js/main.js
@@ -25,6 +25,7 @@ import { RetanguloTool } from './tools/RetanguloTool.js';
 import { TextoTool } from './tools/TextoTool.js';
 import { exportarDesenho } from './utils/exportHelpers.js';
 import { SelectionNodeEditTool } from './tools/SelectionNodeEditTool.js';
+import { NodeEditTool } from './tools/NodeEditTool.js';
 import { Selecao } from './core/Selecao.js';
 import { BorrachaTool } from './tools/BorrachaTool.js';
 import { LinhaTool } from './tools/LinhaTool.js';
@@ -167,6 +168,7 @@ definirGerenciadorSelecao(selecaoVisual);
 const cameraGlobal = new CameraSVG([svgCanvas, overlayCanvas]);
 const instanciasFerramentas = {
   selecao: new SelectionNodeEditTool(svgCanvas),
+  edicaoVertices: new NodeEditTool(svgCanvas),
   retangulo: new RetanguloTool(svgCanvas),
   linha: new LinhaTool(svgCanvas),
   linhaCurvada: new LinhaCurvadaTool(svgCanvas),

--- a/js/main.js
+++ b/js/main.js
@@ -24,10 +24,9 @@ import { Lapis } from './tools/LapisTool.js';
 import { RetanguloTool } from './tools/RetanguloTool.js';
 import { TextoTool } from './tools/TextoTool.js';
 import { exportarDesenho } from './utils/exportHelpers.js';
-import { SelecaoTool } from './tools/SelecaoTool.js';
+import { SelectionNodeEditTool } from './tools/SelectionNodeEditTool.js';
 import { Selecao } from './core/Selecao.js';
 import { BorrachaTool } from './tools/BorrachaTool.js';
-import { NodeEditTool } from './tools/NodeEditTool.js';
 import { LinhaTool } from './tools/LinhaTool.js';
 import { LinhaCurvadaTool } from './tools/LinhaCurvadaTool.js';
 import { ElipseTool } from './tools/ElipseTool.js';
@@ -167,8 +166,7 @@ definirGerenciadorSelecao(selecaoVisual);
 // Instâncias das ferramentas disponíveis com todas as implementações da main
 const cameraGlobal = new CameraSVG([svgCanvas, overlayCanvas]);
 const instanciasFerramentas = {
-  selecao: new SelecaoTool(svgCanvas),
-  edicaoVertices: new NodeEditTool(svgCanvas),
+  selecao: new SelectionNodeEditTool(svgCanvas),
   retangulo: new RetanguloTool(svgCanvas),
   linha: new LinhaTool(svgCanvas),
   linhaCurvada: new LinhaCurvadaTool(svgCanvas),

--- a/js/main.js
+++ b/js/main.js
@@ -264,6 +264,12 @@ svgCanvas.addEventListener('mousemove', (evento) => {
   }
 });
 
+svgCanvas.addEventListener('dblclick', (evento) => {
+  if (estado.ferramentaAtual) {
+    estado.ferramentaAtual.dblclick(evento);
+  }
+})
+
 // Previne o menu de opções do botão direito no canvas
 svgCanvas.addEventListener('contextmenu', (e) => {
   if (e.target.closest('#canvas')) {

--- a/js/tools/SelectionNodeEditTool.js
+++ b/js/tools/SelectionNodeEditTool.js
@@ -2,7 +2,12 @@ import { ToolBase } from './ToolBase.js';
 import { SelecaoTool } from './SelecaoTool.js';
 import { NodeEditTool } from './NodeEditTool.js';
 import { obterCoordenadaSVG } from '../utils/svgHelpers.js';
-import { estado, atualizarPosicaoSelecaoVisual } from '../core/StateManager.js';
+import { estado, 
+    atualizarPosicaoSelecaoVisual,
+    ocultarSelecaoVisual,
+    redesenharSelecaoVisual,
+    definirElementosSelecionados
+    } from '../core/StateManager.js';
 
 
 export class SelectionNodeEditTool extends ToolBase {
@@ -25,52 +30,62 @@ export class SelectionNodeEditTool extends ToolBase {
         this.mouseDownPos = {x: pt.x, y:pt.y};
         this.isDragging = false;
 
+        if (this.modoAtual === 'selecao') {
+            this.selecaoTool.onMouseDown(evento);
+            return
+        }
+
         if (this._isNodeHandle(target)) {
-            this.modoAtual = 'nodeEdit';
             this.isNodeHit = true;
-            this.nodeEditTool.onMouseDown(evento);
+        } else {
+            this.isNodeHit = false;
+        }
+        this.nodeEditTool.onMouseDown(evento);
+        definirElementosSelecionados([target]);
+        ocultarSelecaoVisual();
+    }
+
+    /**
+   *
+   * @param {MouseEvent} evento - Evento nativo do mouse.
+   */
+    dblclick(evento) {
+        const target = evento.target
+        if (!target || target === this.svgCanvas) {
+            return;
+        }
+        if (this.modoAtual === 'selecao') {
+            this.modoAtual = 'nodeEdit';
+            definirElementosSelecionados([target]);
+            ocultarSelecaoVisual();
+            this._sincronizarOverlayNos();
             return;
         }
         this.modoAtual = 'selecao';
-        this.isNodeHit = false;
-        this.selecaoTool.onMouseDown(evento);
-        this._sincronizarOverlayNos();
+        this.nodeEditTool.limparSelecao();
+        redesenharSelecaoVisual();
     }
 
     onMouseMove(evento) {
         if (this.modoAtual === 'nodeEdit' && this.isNodeHit) {
             this.nodeEditTool.onMouseMove(evento);
-            atualizarPosicaoSelecaoVisual();
             return;
         }
 
-        if (this.modoAtual === 'selecao') {
-            if (this.mouseDownPos && !this.isDragging) {
-                const pt = obterCoordenadaSVG(evento, this.svgCanvas)
-                const dx = pt.x - this.mouseDownPos.x;
-                const dy = pt.y - this.mouseDownPos.y;
-                if (Math.sqrt(dx*dx + dy*dy) > 3)
-                    this.isDragging = true;
-            }
-
-            this.selecaoTool.onMouseMove(evento);
-
-            if (this.nodeEditTool.elementoAlvo) {
-                const tag = this.nodeEditTool.elementoAlvo.tagName.toLowerCase();
-                const shape = this.nodeEditTool.allowedShapes[tag];
-                // Atualiza os handles para acompanhar a movimentação do objeto
-                if (shape) {
-                    shape.sincronizarTodosOsHandles(this.nodeEditTool.elementoAlvo);
-                }
-            }
+        if (this.mouseDownPos && !this.isDragging) {
+            const pt = obterCoordenadaSVG(evento, this.svgCanvas)
+            const dx = pt.x - this.mouseDownPos.x;
+            const dy = pt.y - this.mouseDownPos.y;
+            if (Math.sqrt(dx*dx + dy*dy) > 3)
+                this.isDragging = true;
         }
+        this.selecaoTool.onMouseMove(evento);
     }
 
     onMouseUp(evento) {
         if (this.modoAtual === 'nodeEdit' && this.isNodeHit) {
             this.nodeEditTool.onMouseUp(evento);
             this.isNodeHit = false;
-            this.modoAtual = 'selecao';
             return;
         }
 
@@ -88,7 +103,7 @@ export class SelectionNodeEditTool extends ToolBase {
     onDesativar() {
         this.limparSelecao();
         this.isNodeHit = false;
-        this.modoAtual = 'selecao';
+        this.modoAtual            // this.modoAtual = 'selecao'; = 'selecao';
         this.isDragging = false;
         this.mouseDownPos = null;
 
@@ -105,7 +120,7 @@ export class SelectionNodeEditTool extends ToolBase {
      * Lida com o overlay de edição com nós
      * @private
      */
-    _sincronizarOverlayNos() {
+    _sincronizarOverlayNos(target) {
         const selecionados = estado.elementosSelecionados;
         // Garante que edição dos nós só ocorre quando um elemento é selecionado
         const elementoUnico = selecionados.length === 1 ? selecionados[0] : null;

--- a/js/tools/SelectionNodeEditTool.js
+++ b/js/tools/SelectionNodeEditTool.js
@@ -103,7 +103,7 @@ export class SelectionNodeEditTool extends ToolBase {
     onDesativar() {
         this.limparSelecao();
         this.isNodeHit = false;
-        this.modoAtual            // this.modoAtual = 'selecao'; = 'selecao';
+        this.modoAtual = 'selecao';
         this.isDragging = false;
         this.mouseDownPos = null;
 

--- a/js/tools/SelectionNodeEditTool.js
+++ b/js/tools/SelectionNodeEditTool.js
@@ -49,7 +49,7 @@ export class SelectionNodeEditTool extends ToolBase {
    *
    * @param {MouseEvent} evento - Evento nativo do mouse.
    */
-    dblclick(evento) {
+    onDblClick(evento) {
         const target = evento.target
         if (!target || target === this.svgCanvas) {
             return;

--- a/js/tools/SelectionNodeEditTool.js
+++ b/js/tools/SelectionNodeEditTool.js
@@ -1,0 +1,154 @@
+import { ToolBase } from './ToolBase.js';
+import { SelecaoTool } from './SelecaoTool.js';
+import { NodeEditTool } from './NodeEditTool.js';
+import { obterCoordenadaSVG } from '../utils/svgHelpers.js';
+import { estado, atualizarPosicaoSelecaoVisual } from '../core/StateManager.js';
+
+
+export class SelectionNodeEditTool extends ToolBase {
+    constructor(svgCanvas) {
+        super();
+        this.svgCanvas = svgCanvas;
+
+        this.selecaoTool = new SelecaoTool(svgCanvas);
+        this.nodeEditTool = new NodeEditTool(svgCanvas);
+
+        this.modoAtual = 'selecao';
+        this.isNodeHit = false;
+        this.isDragging = false;
+        this.mouseDownPos = null;
+    }
+
+    onMouseDown(evento) {
+        const target = evento.target;
+        const pt = obterCoordenadaSVG(evento, this.svgCanvas);
+        this.mouseDownPos = {x: pt.x, y:pt.y};
+        this.isDragging = false;
+
+        if (this._isNodeHandle(target)) {
+            this.modoAtual = 'nodeEdit';
+            this.isNodeHit = true;
+            this.nodeEditTool.onMouseDown(evento);
+            return;
+        }
+        this.modoAtual = 'selecao';
+        this.isNodeHit = false;
+        this.selecaoTool.onMouseDown(evento);
+        this._sincronizarOverlayNos();
+    }
+
+    onMouseMove(evento) {
+        if (this.modoAtual === 'nodeEdit' && this.isNodeHit) {
+            this.nodeEditTool.onMouseMove(evento);
+            atualizarPosicaoSelecaoVisual();
+            return;
+        }
+
+        if (this.modoAtual === 'selecao') {
+            if (this.mouseDownPos && !this.isDragging) {
+                const pt = obterCoordenadaSVG(evento, this.svgCanvas)
+                const dx = pt.x - this.mouseDownPos.x;
+                const dy = pt.y - this.mouseDownPos.y;
+                if (Math.sqrt(dx*dx + dy*dy) > 3)
+                    this.isDragging = true;
+            }
+
+            this.selecaoTool.onMouseMove(evento);
+
+            if (this.nodeEditTool.elementoAlvo) {
+                const tag = this.nodeEditTool.elementoAlvo.tagName.toLowerCase();
+                const shape = this.nodeEditTool.allowedShapes[tag];
+                // Atualiza os handles para acompanhar a movimentação do objeto
+                if (shape) {
+                    shape.sincronizarTodosOsHandles(this.nodeEditTool.elementoAlvo);
+                }
+            }
+        }
+    }
+
+    onMouseUp(evento) {
+        if (this.modoAtual === 'nodeEdit' && this.isNodeHit) {
+            this.nodeEditTool.onMouseUp(evento);
+            this.isNodeHit = false;
+            this.modoAtual = 'selecao';
+            return;
+        }
+
+        if (this.modoAtual === 'selecao') {
+            this.selecaoTool.onMouseUp(evento);
+            this.isDragging = false;
+            this.mouseDownPos = null;
+        }
+    }
+
+    onKeyDown(evento) {
+        this.selecaoTool.onKeyDown(evento);
+    }
+
+    onDesativar() {
+        this.limparSelecao();
+        this.isNodeHit = false;
+        this.modoAtual = 'selecao';
+        this.isDragging = false;
+        this.mouseDownPos = null;
+
+        this.selecaoTool.onDesativar?.();
+        this.nodeEditTool.onDesativar?.();
+    }
+
+    limparSelecao() {
+        this.selecaoTool.limparSelecao();
+        this.nodeEditTool.limparSelecao();
+    }
+
+    /**
+     * Lida com o overlay de edição com nós
+     * @private
+     */
+    _sincronizarOverlayNos() {
+        const selecionados = estado.elementosSelecionados;
+        // Garante que edição dos nós só ocorre quando um elemento é selecionado
+        const elementoUnico = selecionados.length === 1 ? selecionados[0] : null;
+        if (!elementoUnico) {
+            if (this.nodeEditTool.elementoAlvo) {
+                this.nodeEditTool.limparSelecao();
+            }
+            return;
+        }
+
+        const tag = elementoUnico.tagName.toLocaleLowerCase();
+        const shapeSuportada = this.nodeEditTool.allowedShapes[tag] || null;
+        if (!shapeSuportada) {
+            if (this.nodeEditTool.elementoAlvo) {
+                this.nodeEditTool.limparSelecao();
+            }
+            return;
+        }
+        // Não houve mudanças
+        if (this.nodeEditTool.elementoAlvo === elementoUnico) {
+            return;
+        }
+        // Troca de alvo
+        if (this.nodeEditTool.elementoAlvo) {
+            this.nodeEditTool.limparSelecao();
+        }
+        this.nodeEditTool.elementoAlvo = elementoUnico;
+        shapeSuportada.inicializarOverlay();
+        shapeSuportada.renderizarTodosHandles(elementoUnico);
+    }
+
+    /**
+     * Checa se o elemento selecionado é de um nó
+     * @private
+     */
+    _isNodeHandle(target) {
+        let current = target;
+        while (current && current != this.svgCanvas) {
+            if (current.hasAttribute && current.hasAttribute('data-node-id')) {
+                return true;
+            }
+            current = current.parentNode;
+        }
+        return false;
+    }
+}


### PR DESCRIPTION
Este PR unifica a ferramenta de edição de vértices e a ferramenta de seleção numa só, deixando ambas as funcionalidades na própria ferramenta de seleção.

### Alterações

- Criação de uma nova classe SelectionNodeEditTool que cria as instâncias das duas ferramentas e lida a ativação de cada de acordo com o evento ocorrido;
- Eliminação da utilização de ambas as ferramentas no main;
- Adição da nova ferramenta na main, instanciando na variável de selecao;
- Remoção do botão de Edição dos nós no index.html já que suas funcionalidades estão integradas na de seleção;

### Critérios de Aceite

- [x] Todos os elementos conseguem ser selecionados e arrastados

> **Nota:** Elementos do tipo polilinha já não conseguiam ser selecionados, como estava fora do escopo da issue, ela não foi consertada, mas caso haja permissão, essa função pode ser tratada nesse mesmo PR;

- [x] Para os elementos que são permitidos a edição de nós (retângulo, elipse e imagem), os nós de edição são visíveis e editáveis;
- [x] Clique em um handle e arrastar deve apenas se comportar como edição de nó;
- [x] Clique em qualquer outra parte do elemento e arrastar deve apenas transladar o elemento no quadro;