### PR TITLE
fix: exibe nome legível da ferramenta na topbar (data-nome)

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -189,14 +189,16 @@ const instanciasFerramentas = {
  * @param {string} nomeDaFerramenta - Identificador da ferramenta ativa.
  */
 function atualizarBotaoAtivo(nomeDaFerramenta) {
+  let btnAtivo = null;
   botoesFerramenta.forEach((btn) => {
     if (btn.getAttribute('data-ferramenta') === nomeDaFerramenta) {
       btn.classList.add('ativo');
+      btnAtivo = btn;
     } else {
       btn.classList.remove('ativo');
     }
   });
-  nomeFerramenta.textContent = nomeDaFerramenta || 'Nenhuma';
+  nomeFerramenta.textContent = btnAtivo?.dataset.nome || 'Nenhuma';
 }
 
 // --- Barra de Ferramentas & Modos ---


### PR DESCRIPTION
## Descrição:

Corrige regressão da issue #110: a topbar voltava a exibir o identificador interno da ferramenta (ex: poligono, edicaoVertices) em vez do nome legível (ex: "Polígono / Polilinha", "Edição de Vértices").

atualizarBotaoAtivo agora localiza o botão correspondente à ferramenta ativa e usa btn.dataset.nome para preencher nomeFerramenta.textContent, em vez do identificador bruto (data-ferramenta).