### PR TITLE
feat[53]: seleção múltipla com Shift/Ctrl

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -239,9 +239,10 @@ svgCanvas.addEventListener('mouseup', (evento) => {
 
   // Verifica se a ferramenta de seleção acabou de selecionar um elemento
   // Se houver um elemento selecionado, sincroniza a sidebar com as cores dele
-  if (estado.elementoSelecionado) {
-    const corPreenchimentoAtual = estado.elementoSelecionado.getAttribute('fill') || '#ffffff';
-    const corBordaAtual = estado.elementoSelecionado.getAttribute('stroke') || '#000000';
+  const elementoParaSincronizar = estado.elementosSelecionados[0] || null;
+  if (elementoParaSincronizar) {
+    const corPreenchimentoAtual = elementoParaSincronizar.getAttribute('fill') || '#ffffff';
+    const corBordaAtual = elementoParaSincronizar.getAttribute('stroke') || '#000000';
 
     // Atualiza o valor visual dos inputs para bater com o objeto selecionado
     inputCorPreenchimento.value = corPreenchimentoAtual;

--- a/js/tools/SelecaoTool.js
+++ b/js/tools/SelecaoTool.js
@@ -68,6 +68,7 @@ export class SelecaoTool extends ToolBase {
     const pt = obterCoordenadaSVG(evento, this.svgCanvas);
     const target = evento.target;
     const isShift = evento.shiftKey;
+    const isCtrl = evento.ctrlKey || evento.metaKey;
 
     const allowedTags = ['rect', 'text', 'image', 'circle', 'ellipse', 'g', 'path', 'line', 'lapis'];
     const tag = target.tagName ? target.tagName.toLowerCase() : '';
@@ -76,28 +77,32 @@ export class SelecaoTool extends ToolBase {
     const elementoAlvo = this._buscarElementoValido(target, allowedTags);
 
     if (elementoAlvo) {
-      if (isShift) {
-        // Alterna seleção com Shift
-        if (estado.elementosSelecionados.includes(elementoAlvo)) {
-          removerElementoSelecao(elementoAlvo);
-        } else {
-          adicionarElementoSelecao(elementoAlvo);
-        }
-      } else {
-        if (!estado.elementosSelecionados.includes(elementoAlvo)) {
-          definirElementosSelecionados([elementoAlvo]);
-        }
-      }
+      this._aplicarSelecaoComModificador(elementoAlvo, isShift, isCtrl);
 
       if (estado.elementosSelecionados.length > 0) {
         this.isDragging = true;
         this._calcularOffsets(pt);
         this._salvarEstadoInicialMovimento();
       }
-    } else {
-      if (!isShift) {
-        this.limparSelecao();
+    } else if (!isShift && !isCtrl) {
+      this.limparSelecao();
+    }
+  }
+
+  _aplicarSelecaoComModificador(elementoAlvo, isShift, isCtrl) {
+    const usaModificador = isShift || isCtrl;
+
+    if (!usaModificador) {
+      if (!estado.elementosSelecionados.includes(elementoAlvo)) {
+        definirElementosSelecionados([elementoAlvo]);
       }
+      return;
+    }
+
+    if (estado.elementosSelecionados.includes(elementoAlvo)) {
+      removerElementoSelecao(elementoAlvo);
+    } else {
+      adicionarElementoSelecao(elementoAlvo);
     }
   }
 


### PR DESCRIPTION
A funcionalidade de seleção múltipla foi integrada ao editor com suporte a Shift e Ctrl/Cmd.

O que mudou:

-Clique simples: seleciona apenas o elemento clicado.
-Shift: adiciona ou remove o elemento da seleção sem limpar os demais.
-Ctrl/Cmd: também alterna a inclusão do elemento na seleção.

-Arraste: move todos os elementos selecionados em conjunto.

-A sidebar agora sincroniza as cores com o primeiro elemento da seleção, mantendo a interface consistente.