### PR TITLE
[Feature] Implementar espelhamento horizontal e vertical de objetos (#164)

### DIFF
--- a/index.html
+++ b/index.html
@@ -71,6 +71,14 @@
                 <button id="btn-bring-to-front" title="Trazer para a Frente" class="btn-layer">⏭</button>
             </div>
 
+            <button id="btn-flip-horizontal" class="btn-layer" title="Espelhar Horizontal">
+                ↔
+            </button>
+
+            <button id="btn-flip-vertical" class="btn-layer" title="Espelhar Vertical">
+                ↕
+            </button>
+
             <!-- Botão de exportar/descarregar desenho -->
             <button id="btn-primeiros-passos" class="btn-ajuda">
                 <i class="btn-primeiros-passos-i" data-lucide="info"></i>

--- a/js/main.js
+++ b/js/main.js
@@ -14,17 +14,18 @@ import {
   definirCorBorda, 
   definirGerenciadorSelecao,
   definirElementosSelecionados,
-  definirGerenciadorSelecao,
   definirGerenciadorHistorico,
   desfazerAcao,
   refazerAcao,
-  registrarAcaoHistorico
+  registrarAcaoHistorico,
+  atualizarPosicaoSelecaoVisual
 } from './core/StateManager.js';
 import { ColorPickerTool } from './tools/ColorPickerTool.js';
 import { Lapis } from './tools/LapisTool.js';
 import { RetanguloTool } from './tools/RetanguloTool.js';
 import { TextoTool } from './tools/TextoTool.js';
 import { exportarDesenho } from './utils/exportHelpers.js';
+import { espelharHorizontal, espelharVertical } from './utils/flipHelpers.js';
 import { SelecaoTool } from './tools/SelecaoTool.js';
 import { Selecao } from './core/Selecao.js';
 import { BorrachaTool } from './tools/BorrachaTool.js';
@@ -288,6 +289,31 @@ btnSendToBack.addEventListener('click', () => moverCamada('fundo'));
 btnStepBackward.addEventListener('click', () => moverCamada('recuar'));
 btnStepForward.addEventListener('click', () => moverCamada('avancar'));
 btnBringToFront.addEventListener('click', () => moverCamada('frente'));
+
+const btnFlipHorizontal = document.getElementById('btn-flip-horizontal');
+const btnFlipVertical = document.getElementById('btn-flip-vertical');
+
+btnFlipHorizontal.addEventListener("click", () => {
+
+    estado.elementosSelecionados.forEach(el => {
+        espelharHorizontal(el);
+    });
+
+    atualizarPosicaoSelecaoVisual();
+    registrarAcaoHistorico();
+
+});
+
+btnFlipVertical.addEventListener("click", () => {
+
+    estado.elementosSelecionados.forEach(el => {
+        espelharVertical(el);
+    });
+
+    atualizarPosicaoSelecaoVisual();
+    registrarAcaoHistorico();
+
+});
 
 // Atalhos de Teclado (Tool Selection)
 window.addEventListener("keydown", (e) => {

--- a/js/tools/SelecaoTool.js
+++ b/js/tools/SelecaoTool.js
@@ -8,6 +8,7 @@ import {
   atualizarPosicaoSelecaoVisual,
   registrarAcaoHistorico
 } from '../core/StateManager.js';
+import { atualizarTransformacao } from '../utils/flipHelpers.js';
 
 /**
  * Ferramenta de Seleção
@@ -74,12 +75,18 @@ export class SelecaoTool extends ToolBase {
       const tag = el.tagName.toLowerCase();
 
       // Atualiza coordenadas baseado no tipo de elemento
-      if (tag === 'rect' || tag === 'text' || tag === 'image') {
+      if (tag === 'rect') {
         el.setAttribute('x', String(novoX));
         el.setAttribute('y', String(novoY));
+        atualizarTransformacao(el);
+      } else if (tag === 'text' || tag === 'image') {
+        el.setAttribute('x', String(novoX));
+        el.setAttribute('y', String(novoY));
+        atualizarTransformacao(el);
       } else if (tag === 'circle' || tag === 'ellipse') {
         el.setAttribute('cx', String(novoX));
         el.setAttribute('cy', String(novoY));
+        atualizarTransformacao(el);
       } else if (tag === 'line') {
           // Exemplo simplificado para linha (move mantendo comprimento)
           const dx = novoX - parseFloat(el.getAttribute('x1') || 0);
@@ -89,9 +96,9 @@ export class SelecaoTool extends ToolBase {
           el.setAttribute('x2', String(parseFloat(el.getAttribute('x2') || 0) + dx));
           el.setAttribute('y2', String(parseFloat(el.getAttribute('y2') || 0) + dy));
       } else if (tag === 'path' || tag === 'g') {
-          //Usa a tranformação de translação, a mesma que foi vista em sala :), pra mover o objeto
-          el.setAttribute('transform', `translate(${novoX}, ${novoY})`);
-          // Guarda a posição atual para o próximo clique
+          el.dataset.translateX = novoX;
+          el.dataset.translateY = novoY;
+          atualizarTransformacao(el);
           el.setAttribute('data-x', String(novoX));
           el.setAttribute('data-y', String(novoY));
       }

--- a/js/utils/flipHelpers.js
+++ b/js/utils/flipHelpers.js
@@ -1,0 +1,116 @@
+function obterCentro(elemento) {
+
+    const box = elemento.getBBox();
+
+    return {
+        cx: box.x + box.width / 2,
+        cy: box.y + box.height / 2
+    };
+
+}
+
+function numero(elemento, atributo) {
+    return parseFloat(elemento.getAttribute(atributo) || 0);
+}
+
+export function atualizarTransformacao(elemento) {
+
+    const { cx, cy } = obterCentro(elemento);
+
+    const flipH = elemento.dataset.flipH === "true";
+    const flipV = elemento.dataset.flipV === "true";
+
+    const scaleX = flipH ? -1 : 1;
+    const scaleY = flipV ? -1 : 1;
+
+    const tx = parseFloat(elemento.dataset.translateX || 0);
+    const ty = parseFloat(elemento.dataset.translateY || 0);
+
+    elemento.setAttribute(
+        "transform",
+        `translate(${tx}, ${ty})
+         translate(${cx}, ${cy})
+         scale(${scaleX}, ${scaleY})
+         translate(${-cx}, ${-cy})`
+    );
+}
+
+function alternarEspelhamentoHorizontal(elemento) {
+
+    elemento.dataset.flipH =
+        elemento.dataset.flipH === "true" ? "false" : "true";
+
+    atualizarTransformacao(elemento);
+}
+
+function alternarEspelhamentoVertical(elemento) {
+
+    elemento.dataset.flipV =
+        elemento.dataset.flipV === "true" ? "false" : "true";
+
+    atualizarTransformacao(elemento);
+}
+
+export function espelharHorizontal(elemento) {
+
+    const tag = elemento.tagName.toLowerCase();
+
+    // Linha
+    if (tag === "line") {
+
+        const { cx } = obterCentro(elemento);
+
+        const x1 = numero(elemento, "x1");
+        const x2 = numero(elemento, "x2");
+
+        elemento.setAttribute("x1", 2 * cx - x1);
+        elemento.setAttribute("x2", 2 * cx - x2);
+
+        return;
+    }
+
+    // Imagem, Texto, Retangulo, Desenho a Lapis e Circulo/Elipse
+    if (
+        tag === "image" ||
+        tag === "text" ||
+        tag === "rect" ||
+        tag === "path" ||
+        tag === "circle" ||
+        tag === "ellipse"
+    ) {
+        alternarEspelhamentoHorizontal(elemento);
+        return;
+    }
+}
+
+export function espelharVertical(elemento) {
+
+    const tag = elemento.tagName.toLowerCase();
+
+    // Linha
+    if (tag === "line") {
+
+        const { cy } = obterCentro(elemento);
+
+        const y1 = numero(elemento, "y1");
+        const y2 = numero(elemento, "y2");
+
+        elemento.setAttribute("y1", 2 * cy - y1);
+        elemento.setAttribute("y2", 2 * cy - y2);
+
+        return;
+    }
+
+    // Imagem, Texto, Retangulo, Desenho a Lapis e Circulo/Elipse
+    if (
+        tag === "image" ||
+        tag === "text" ||
+        tag === "rect" ||
+        tag === "path" ||
+        tag === "circle" ||
+        tag === "ellipse"
+    ) {
+        alternarEspelhamentoVertical(elemento);
+        return;
+    }
+}


### PR DESCRIPTION
## Descrição

Este PR implementa a funcionalidade de espelhamento horizontal e vertical para objetos selecionados no editor vetorial.

A solução foi implementada de forma reutilizável, permitindo combinar os dois tipos de espelhamento e alterná-los individualmente.

## Elementos suportados

- ✅ Linha
- ✅ Retângulo
- ✅ Círculo
- ✅ Elipse
- ✅ Texto
- ✅ Imagem
- ✅ Desenhos feitos com a ferramenta Lápis (`path`)

## Alterações realizadas

- Implementação do espelhamento horizontal.
- Implementação do espelhamento vertical.
- Comportamento de alternância (toggle) para ambos os espelhamentos.
- Refatoração da lógica de transformação em um utilitário reutilizável.
- Integração da funcionalidade com a ferramenta de seleção.

## Correções realizadas

Durante o desenvolvimento foram identificados e corrigidos dois problemas relacionados ao uso do atributo `transform`:

- Objetos espelhados mantêm o espelhamento após serem movidos.
- Imagens espelhadas não apresentam mais movimentação invertida.

## Como testar

1. Criar ou importar qualquer objeto suportado.
2. Selecioná-lo.
3. Aplicar espelhamento horizontal e/ou vertical.
4. Mover o objeto pelo canvas.
5. Alternar novamente os espelhamentos.

O comportamento esperado é que o objeto preserve corretamente sua orientação durante toda a interação.

Closes #164