### PR TITLE
Feat 108/projecao elementos 3d canvas

### DIFF
--- a/index.html
+++ b/index.html
@@ -149,6 +149,15 @@
                     >
                         &#9135;
                     </button>
+                    <button 
+                        id="btn-criar-cubo" 
+                        class="btn-ferramenta" 
+                        data-ferramenta="cubo" 
+                        data-nome="Cubo 3D" 
+                        data-tooltip="Cubo 3D (3)" 
+                    > 
+                        &#129482; 
+                    </button>
                     <button
                         id="btn-criar-polilinha"
                         class="btn-ferramenta"

--- a/js/core/Projection3D.js
+++ b/js/core/Projection3D.js
@@ -28,3 +28,17 @@ export function projectPerspective(x, y, z, { originX = 0, originY = 0, scale = 
     y: originY - y * scale * depth,
   };
 }
+
+/**
+ * Calcula a normal de uma face a partir de 3 vértices projetados (2D).
+ * Retorna o componente Z do produto vetorial — se negativo, a face está voltada para a câmera.
+ * @param {{ x, y }} p0
+ * @param {{ x, y }} p1
+ * @param {{ x, y }} p2
+ * @returns {number}
+ */
+export function computeFaceNormalZ(p0, p1, p2) {
+  const ax = p1.x - p0.x, ay = p1.y - p0.y;
+  const bx = p2.x - p0.x, by = p2.y - p0.y;
+  return ax * by - ay * bx; // Z do produto vetorial
+}

--- a/js/core/Projection3D.js
+++ b/js/core/Projection3D.js
@@ -12,3 +12,19 @@ export function projectIsometric(x, y, z, { originX = 0, originY = 0, scale = 1 
   const screenY = originY + (x + z) * Math.sin(angle) * scale - y * scale;
   return { x: screenX, y: screenY };
 }
+
+/**
+ * Projeta um vértice 3D para coordenadas 2D usando projeção em perspectiva.
+ * @param {number} x
+ * @param {number} y
+ * @param {number} z
+ * @param {{ originX, originY, scale, fov }} opts
+ * @returns {{ x: number, y: number }}
+ */
+export function projectPerspective(x, y, z, { originX = 0, originY = 0, scale = 1, fov = 500 } = {}) {
+  const depth = fov / (fov + z * scale);
+  return {
+    x: originX + x * scale * depth,
+    y: originY - y * scale * depth,
+  };
+}

--- a/js/core/Projection3D.js
+++ b/js/core/Projection3D.js
@@ -1,0 +1,14 @@
+/**
+ * Projeta um vértice 3D para coordenadas 2D usando projeção isométrica.
+ * @param {number} x
+ * @param {number} y
+ * @param {number} z
+ * @param {{ originX: number, originY: number, scale: number }} opts
+ * @returns {{ x: number, y: number }}
+ */
+export function projectIsometric(x, y, z, { originX = 0, originY = 0, scale = 1 } = {}) {
+  const angle = Math.PI / 6; // 30°
+  const screenX = originX + (x - z) * Math.cos(angle) * scale;
+  const screenY = originY + (x + z) * Math.sin(angle) * scale - y * scale;
+  return { x: screenX, y: screenY };
+}

--- a/js/core/Projection3D.js
+++ b/js/core/Projection3D.js
@@ -42,3 +42,15 @@ export function computeFaceNormalZ(p0, p1, p2) {
   const bx = p2.x - p0.x, by = p2.y - p0.y;
   return ax * by - ay * bx; // Z do produto vetorial
 }
+
+/**
+ * Calcula a profundidade média de uma face no espaço 3D.
+ * Usado pelo Painter's Algorithm para ordenar faces.
+ * @param {number[]} faceIndices - Índices dos vértices da face
+ * @param {{ x,y,z }[]} vertices3D
+ * @returns {number}
+ */
+export function computeFaceDepth(faceIndices, vertices3D) {
+  const sum = faceIndices.reduce((acc, i) => acc + vertices3D[i].z, 0);
+  return sum / faceIndices.length;
+}

--- a/js/main.js
+++ b/js/main.js
@@ -322,7 +322,8 @@ window.addEventListener("keydown", (e) => {
     "l" : "linha",
     "p" : "poligono",
     "t" : "texto",
-    "i" : "conta-gotas"
+    "i" : "conta-gotas",
+    "3": "cubo"
   }
 
   const teclaPressionada = e.key.toLowerCase();

--- a/js/main.js
+++ b/js/main.js
@@ -34,6 +34,7 @@ import { inicializarImportadorImagem } from './tools/ImageImporter.js';
 import { inicializarMenuInicial } from './core/UIManager.js';
 import { PoligonoPolilinhaTool } from './tools/PoligonoPolilinhaTool.js';
 import { HistoryManager } from './core/HistoryManager.js';
+import { CuboTool } from './tools/CuboTool.js';
 
 const svgCanvas = document.getElementById('canvas');
 
@@ -165,6 +166,7 @@ const instanciasFerramentas = {
   texto: new TextoTool(svgCanvas),
   borracha: new BorrachaTool(svgCanvas),
   lapis: new Lapis(svgCanvas),
+  cubo: new CuboTool(svgCanvas),
 };
 
 /**

--- a/js/main.js
+++ b/js/main.js
@@ -243,13 +243,23 @@ botoesFerramenta.forEach((btn) => {
     atualizarBotaoAtivo(ferramentaId);
   });
 });
-
 // Ouvir mudanças no input de cor de preenchimento da sidebar
 inputCorPreenchimento.addEventListener('input', () => {
   const novaCor = inputCorPreenchimento.value;
   definirCorPreenchimento(novaCor);
-  // Preenche cada elemento selecionado com a cor desejada
+
   estado.elementosSelecionados.forEach(el => {
+
+    // Cubo
+    if (el.classList.contains('cubo-3d')) {
+      el.querySelectorAll('polygon').forEach(face => {
+        const brilho = FACE_BRIGHTNESS[face.dataset.face] ?? 0.8;
+        face.setAttribute('fill', ajustarBrilho(novaCor, brilho));
+      });
+      return;
+    }
+
+    // Demais elementos
     el.setAttribute('fill', novaCor);
   });
 });
@@ -258,11 +268,40 @@ inputCorPreenchimento.addEventListener('input', () => {
 inputCorBorda.addEventListener('input', () => {
   const novaCor = inputCorBorda.value;
   definirCorBorda(novaCor);
-  // Colore a borda de cada elemento selecionado com a cor desejada
+
   estado.elementosSelecionados.forEach(el => {
+
+    // Cubo
+    if (el.classList.contains('cubo-3d')) {
+      el.querySelectorAll('polygon').forEach(face => {
+        face.setAttribute('stroke', novaCor);
+      });
+      return;
+    }
+
+    // Demais elementos
     el.setAttribute('stroke', novaCor);
   });
 });
+
+const FACE_BRIGHTNESS = {
+  frente: 1.00,
+  direita: 0.85,
+  esquerda: 0.70,
+  topo: 0.95,
+  fundo: 0.55,
+  'trás': 0.65,
+};
+
+function ajustarBrilho(hex, fator) {
+  const r = parseInt(hex.slice(1, 3), 16);
+  const g = parseInt(hex.slice(3, 5), 16);
+  const b = parseInt(hex.slice(5, 7), 16);
+
+  const clamp = v => Math.min(255, Math.max(0, Math.round(v * fator)));
+
+  return `rgb(${clamp(r)}, ${clamp(g)}, ${clamp(b)})`;
+}
 
 function atualizarBotaoEstiloLinhaAtivo(estiloLinha) {
   botoesEstiloLinha.forEach((btn) => {

--- a/js/shape/CuboShape.js
+++ b/js/shape/CuboShape.js
@@ -1,0 +1,41 @@
+/**
+ * Gera os 8 vértices de um cubo centrado na origem, com tamanho `size`.
+ * @param {number} size - Metade do comprimento de cada aresta.
+ * @returns {{ x, y, z }[]}
+ */
+export function getCubeVertices(size = 1) {
+  const h = size / 2;
+  return [
+    { x: -h, y: -h, z: -h }, // 0: fundo-esquerda-trás
+    { x:  h, y: -h, z: -h }, // 1: fundo-direita-trás
+    { x:  h, y:  h, z: -h }, // 2: topo-direita-trás
+    { x: -h, y:  h, z: -h }, // 3: topo-esquerda-trás
+    { x: -h, y: -h, z:  h }, // 4: fundo-esquerda-frente
+    { x:  h, y: -h, z:  h }, // 5: fundo-direita-frente
+    { x:  h, y:  h, z:  h }, // 6: topo-direita-frente
+    { x: -h, y:  h, z:  h }, // 7: topo-esquerda-frente
+  ];
+}
+
+/**
+ * Define as 6 faces do cubo.
+ * Cada face é um array de 4 índices de vértice, em ordem anti-horária
+ * vista de fora — isso garante que a normal aponte para fora.
+ */
+export const CUBE_FACES = [
+  { indices: [4, 5, 6, 7], label: 'frente'  },
+  { indices: [1, 0, 3, 2], label: 'trás'    },
+  { indices: [0, 4, 7, 3], label: 'esquerda' },
+  { indices: [5, 1, 2, 6], label: 'direita'  },
+  { indices: [7, 6, 2, 3], label: 'topo'     },
+  { indices: [0, 1, 5, 4], label: 'fundo'    },
+];
+
+/**
+ * Define as 12 arestas do cubo (para debug ou modo wireframe).
+ */
+export const CUBE_EDGES = [
+  [0,1],[1,2],[2,3],[3,0], // face traseira
+  [4,5],[5,6],[6,7],[7,4], // face frontal
+  [0,4],[1,5],[2,6],[3,7], // conexões frente-trás
+];

--- a/js/tools/BorrachaTool.js
+++ b/js/tools/BorrachaTool.js
@@ -26,20 +26,22 @@ export class BorrachaTool extends ToolBase {
     this.isErasing = false;
   }
 
-  apagarElemento(evento) {
-    const target = evento.target;
+ apagarElemento(evento) {
+  const allowedTags = ['rect', 'text', 'image', 'circle', 'ellipse', 'line', 'path', 'polyline', 'g', 'polygon'];
 
-    const allowedTags = ['rect', 'text', 'image', 'circle', 'ellipse', 'line', 'path', 'polygon', 'polyline'];
+  let target = evento.target;
+
+  while (target && target !== this.svgCanvas) {
     const tag = target.tagName ? target.tagName.toLowerCase() : '';
 
-    if (
-      target !== this.svgCanvas &&
-      target.parentNode === this.svgCanvas &&
-      allowedTags.includes(tag)
-    ) {
+    if (allowedTags.includes(tag) && target.parentNode === this.svgCanvas) {
       target.remove();
+      return;
     }
+
+    target = target.parentNode;
   }
+}
 
   onDesativar() {
     this.isErasing = false;

--- a/js/tools/CuboTool.js
+++ b/js/tools/CuboTool.js
@@ -1,3 +1,19 @@
+import { ToolBase } from './ToolBase.js';
+import { getCubeVertices, CUBE_FACES } from '../shape/CuboShape.js';
+import { projectIsometric, computeFaceNormalZ, computeFaceDepth } from '../core/Projection3D.js';
+
+const NS = 'http://www.w3.org/2000/svg';
+
+// Mapa de luminosidade por face — simula iluminação direcional simples
+const FACE_BRIGHTNESS = {
+  frente:    1.00,
+  direita:   0.85,
+  esquerda:  0.70,
+  topo:      0.95,
+  fundo:     0.55,
+  'trás':    0.65,
+};
+
 export class CuboTool extends ToolBase {
   constructor(svgCanvas) {
     super();

--- a/js/tools/CuboTool.js
+++ b/js/tools/CuboTool.js
@@ -2,6 +2,7 @@ import { ToolBase } from './ToolBase.js';
 import { getCubeVertices, CUBE_FACES } from '../shape/CuboShape.js';
 import { projectIsometric, computeFaceNormalZ, computeFaceDepth } from '../core/Projection3D.js';
 import { registrarAcaoHistorico } from '../core/StateManager.js';
+import { estado } from '../core/StateManager.js';
 
 const NS = 'http://www.w3.org/2000/svg';
 
@@ -131,8 +132,8 @@ export class CuboTool extends ToolBase {
       }))
       .sort((a, b) => b.profundidade - a.profundidade); // mais fundo primeiro
 
-    const corBase = '#4a90d9';
-    const corBorda = '#1a1a2e';
+    const corBase = estado.corPreenchimento;
+    const corBorda = estado.corBorda;
 
     for (const face of facesOrdenadas) {
       const pts2D = face.indices.map(i => vertices2D[i]);

--- a/js/tools/CuboTool.js
+++ b/js/tools/CuboTool.js
@@ -6,4 +6,13 @@ export class CuboTool extends ToolBase {
     this._origem = null;       // ponto onde o mousedown ocorreu
     this._grupoPreview = null; // <g> temporário mostrado durante o drag
   }
+
+  onAtivar() {
+    this.canvas.style.cursor = 'crosshair';
+  }
+
+  onDesativar() {
+    this.canvas.style.cursor = 'default';
+    this._limparPreview();
+  }
 }

--- a/js/tools/CuboTool.js
+++ b/js/tools/CuboTool.js
@@ -1,6 +1,7 @@
 import { ToolBase } from './ToolBase.js';
 import { getCubeVertices, CUBE_FACES } from '../shape/CuboShape.js';
 import { projectIsometric, computeFaceNormalZ, computeFaceDepth } from '../core/Projection3D.js';
+import { registrarAcaoHistorico } from '../core/StateManager.js';
 
 const NS = 'http://www.w3.org/2000/svg';
 
@@ -63,6 +64,13 @@ export class CuboTool extends ToolBase {
     const grupo = this._criarGrupo();
     this._renderizarCubo(grupo, this._origem, tamanho, 1.0);
     this.canvas.appendChild(grupo);
+    registrarAcaoHistorico({
+      tipo: 'criacao',
+      elemento: grupo
+    });
+
+    this._desenhando = false;
+    this._origem = null;
   }
 
   // ── Auxiliares ────────────────────────────────────────────

--- a/js/tools/CuboTool.js
+++ b/js/tools/CuboTool.js
@@ -1,0 +1,9 @@
+export class CuboTool extends ToolBase {
+  constructor(svgCanvas) {
+    super();
+    this.canvas = svgCanvas;
+    this._desenhando = false;
+    this._origem = null;       // ponto onde o mousedown ocorreu
+    this._grupoPreview = null; // <g> temporário mostrado durante o drag
+  }
+}

--- a/js/tools/CuboTool.js
+++ b/js/tools/CuboTool.js
@@ -70,11 +70,19 @@ export class CuboTool extends ToolBase {
   _coordenadasSVG(evento) {
     const rect = this.canvas.getBoundingClientRect();
     const vb = this.canvas.viewBox.baseVal;
-    const scaleX = vb.width  ? vb.width  / rect.width  : 1;
-    const scaleY = vb.height ? vb.height / rect.height : 1;
+
+    // Se não há viewBox, usa as dimensões físicas do elemento
+    const width  = vb && vb.width  ? vb.width  : rect.width;
+    const height = vb && vb.height ? vb.height : rect.height;
+    const originX = vb ? vb.x : 0;
+    const originY = vb ? vb.y : 0;
+
+    const scaleX = width  / rect.width;
+    const scaleY = height / rect.height;
+
     return {
-      x: (evento.clientX - rect.left) * scaleX + vb.x,
-      y: (evento.clientY - rect.top)  * scaleY + vb.y,
+        x: (evento.clientX - rect.left) * scaleX + originX,
+        y: (evento.clientY - rect.top)  * scaleY + originY,
     };
   }
 

--- a/js/tools/CuboTool.js
+++ b/js/tools/CuboTool.js
@@ -15,4 +15,37 @@ export class CuboTool extends ToolBase {
     this.canvas.style.cursor = 'default';
     this._limparPreview();
   }
+
+  onMouseDown(evento) {
+    if (evento.button !== 0) return;
+    const { x, y } = this._coordenadasSVG(evento);
+    this._desenhando = true;
+    this._origem = { x, y };
+    this._grupoPreview = this._criarGrupo();
+    this.canvas.appendChild(this._grupoPreview);
+  }
+
+  onMouseMove(evento) {
+    if (!this._desenhando) return;
+    const { x, y } = this._coordenadasSVG(evento);
+    const tamanho = this._calcularTamanho(this._origem, { x, y });
+    this._renderizarCubo(this._grupoPreview, this._origem, tamanho, 0.4);
+  }
+
+  onMouseUp(evento) {
+    if (!this._desenhando) return;
+    const { x, y } = this._coordenadasSVG(evento);
+    const tamanho = this._calcularTamanho(this._origem, { x, y });
+
+    this._limparPreview();
+
+    if (tamanho < 10) {
+      this._desenhando = false;
+      return;
+    }
+
+    const grupo = this._criarGrupo();
+    this._renderizarCubo(grupo, this._origem, tamanho, 1.0);
+    this.canvas.appendChild(grupo);
+  }
 }

--- a/js/tools/CuboTool.js
+++ b/js/tools/CuboTool.js
@@ -48,4 +48,91 @@ export class CuboTool extends ToolBase {
     this._renderizarCubo(grupo, this._origem, tamanho, 1.0);
     this.canvas.appendChild(grupo);
   }
+
+  // ── Auxiliares ────────────────────────────────────────────
+
+  _coordenadasSVG(evento) {
+    const rect = this.canvas.getBoundingClientRect();
+    const vb = this.canvas.viewBox.baseVal;
+    const scaleX = vb.width  ? vb.width  / rect.width  : 1;
+    const scaleY = vb.height ? vb.height / rect.height : 1;
+    return {
+      x: (evento.clientX - rect.left) * scaleX + vb.x,
+      y: (evento.clientY - rect.top)  * scaleY + vb.y,
+    };
+  }
+
+  _calcularTamanho(a, b) {
+    return Math.max(Math.abs(b.x - a.x), Math.abs(b.y - a.y));
+  }
+
+  _criarGrupo() {
+    const g = document.createElementNS(NS, 'g');
+    g.setAttribute('class', 'cubo-3d');
+    return g;
+  }
+
+  _limparPreview() {
+    if (this._grupoPreview) {
+      this._grupoPreview.remove();
+      this._grupoPreview = null;
+    }
+  }
+
+  _renderizarCubo(grupo, centro, tamanho, opacidade = 1) {
+    // Limpa o grupo antes de redesenhar (para preview em tempo real)
+    while (grupo.firstChild) grupo.removeChild(grupo.firstChild);
+
+    const vertices3D = getCubeVertices(tamanho);
+    const projOpts = { originX: centro.x, originY: centro.y, scale: 1 };
+
+    // Projeta todos os vértices para 2D
+    const vertices2D = vertices3D.map(v =>
+      projectIsometric(v.x, v.y, v.z, projOpts)
+    );
+
+    // Calcula profundidade de cada face (Painter's Algorithm)
+    const facesOrdenadas = CUBE_FACES
+      .map(face => ({
+        ...face,
+        profundidade: computeFaceDepth(face.indices, vertices3D),
+      }))
+      .sort((a, b) => b.profundidade - a.profundidade); // mais fundo primeiro
+
+    const corBase = '#4a90d9';
+    const corBorda = '#1a1a2e';
+
+    for (const face of facesOrdenadas) {
+      const pts2D = face.indices.map(i => vertices2D[i]);
+
+      // Back-face culling: descarta faces voltadas para trás
+      const normalZ = computeFaceNormalZ(pts2D[0], pts2D[1], pts2D[2]);
+      if (normalZ >= 0) continue;
+
+      const pontosStr = pts2D.map(p => `${p.x.toFixed(2)},${p.y.toFixed(2)}`).join(' ');
+      const brilho = FACE_BRIGHTNESS[face.label] ?? 0.8;
+
+      const poly = document.createElementNS(NS, 'polygon');
+      poly.setAttribute('points', pontosStr);
+      poly.setAttribute('fill', this._ajustarBrilho(corBase, brilho));
+      poly.setAttribute('stroke', corBorda);
+      poly.setAttribute('stroke-width', '1');
+      poly.setAttribute('stroke-linejoin', 'round');
+      poly.setAttribute('opacity', String(opacidade));
+      poly.setAttribute('data-face', face.label);
+
+      grupo.appendChild(poly);
+    }
+  }
+
+  /**
+   * Ajusta o brilho de uma cor hex multiplicando cada canal por `fator`.
+   */
+  _ajustarBrilho(hex, fator) {
+    const r = parseInt(hex.slice(1, 3), 16);
+    const g = parseInt(hex.slice(3, 5), 16);
+    const b = parseInt(hex.slice(5, 7), 16);
+    const clamp = v => Math.min(255, Math.max(0, Math.round(v * fator)));
+    return `rgb(${clamp(r)}, ${clamp(g)}, ${clamp(b)})`;
+  }
 }

--- a/js/tools/SelecaoTool.js
+++ b/js/tools/SelecaoTool.js
@@ -164,6 +164,9 @@ export class SelecaoTool extends ToolBase {
       } else if (tag === 'line') {
         x = parseFloat(el.getAttribute('x1') || 0);
         y = parseFloat(el.getAttribute('y1') || 0);
+      }else if (tag === 'path' || tag === 'g' || tag === 'polygon') {
+        x = parseFloat(el.getAttribute('data-x') || 0);
+        y = parseFloat(el.getAttribute('data-y') || 0);
       }
       
       return { elemento: el, x, y, tag };
@@ -190,7 +193,10 @@ export class SelecaoTool extends ToolBase {
       } else if (tag === 'line') {
         xAtual = parseFloat(el.getAttribute('x1') || 0);
         yAtual = parseFloat(el.getAttribute('y1') || 0);
-      }
+      }else if (tag === 'g') {
+        xAtual = parseFloat(el.getAttribute('data-x') || 0);
+        yAtual = parseFloat(el.getAttribute('data-y') || 0);
+}
       
       if (xAtual !== estadoInicial.x || yAtual !== estadoInicial.y) {
         return true;

--- a/js/utils/flipHelpers.js
+++ b/js/utils/flipHelpers.js
@@ -1,16 +1,34 @@
 function obterCentro(elemento) {
-
     const box = elemento.getBBox();
 
     return {
         cx: box.x + box.width / 2,
         cy: box.y + box.height / 2
     };
-
 }
 
 function numero(elemento, atributo) {
     return parseFloat(elemento.getAttribute(atributo) || 0);
+}
+
+/**
+ * Lê a translação atual do elemento a partir da lista de transformações SVG.
+ */
+function obterTranslacao(elemento) {
+    const transformList = elemento.transform.baseVal;
+
+    for (let i = 0; i < transformList.numberOfItems; i++) {
+        const item = transformList.getItem(i);
+
+        if (item.type === SVGTransform.SVG_TRANSFORM_TRANSLATE) {
+            return {
+                x: item.matrix.e,
+                y: item.matrix.f
+            };
+        }
+    }
+
+    return { x: 0, y: 0 };
 }
 
 export function atualizarTransformacao(elemento) {
@@ -23,8 +41,8 @@ export function atualizarTransformacao(elemento) {
     const scaleX = flipH ? -1 : 1;
     const scaleY = flipV ? -1 : 1;
 
-    const tx = parseFloat(elemento.dataset.translateX || 0);
-    const ty = parseFloat(elemento.dataset.translateY || 0);
+    // Lê a translação real do SVG
+    const { x: tx, y: ty } = obterTranslacao(elemento);
 
     elemento.setAttribute(
         "transform",
@@ -36,7 +54,6 @@ export function atualizarTransformacao(elemento) {
 }
 
 function alternarEspelhamentoHorizontal(elemento) {
-
     elemento.dataset.flipH =
         elemento.dataset.flipH === "true" ? "false" : "true";
 
@@ -44,7 +61,6 @@ function alternarEspelhamentoHorizontal(elemento) {
 }
 
 function alternarEspelhamentoVertical(elemento) {
-
     elemento.dataset.flipV =
         elemento.dataset.flipV === "true" ? "false" : "true";
 
@@ -55,7 +71,6 @@ export function espelharHorizontal(elemento) {
 
     const tag = elemento.tagName.toLowerCase();
 
-    // Linha
     if (tag === "line") {
 
         const { cx } = obterCentro(elemento);
@@ -69,7 +84,6 @@ export function espelharHorizontal(elemento) {
         return;
     }
 
-    // Imagem, Texto, Retangulo, Desenho a Lapis e Circulo/Elipse
     if (
         tag === "image" ||
         tag === "text" ||
@@ -80,7 +94,6 @@ export function espelharHorizontal(elemento) {
         tag === "g"
     ) {
         alternarEspelhamentoHorizontal(elemento);
-        return;
     }
 }
 
@@ -88,7 +101,6 @@ export function espelharVertical(elemento) {
 
     const tag = elemento.tagName.toLowerCase();
 
-    // Linha
     if (tag === "line") {
 
         const { cy } = obterCentro(elemento);
@@ -102,7 +114,6 @@ export function espelharVertical(elemento) {
         return;
     }
 
-    // Imagem, Texto, Retangulo, Desenho a Lapis e Circulo/Elipse
     if (
         tag === "image" ||
         tag === "text" ||
@@ -110,9 +121,8 @@ export function espelharVertical(elemento) {
         tag === "path" ||
         tag === "circle" ||
         tag === "ellipse" ||
-         tag === "g"
+        tag === "g"
     ) {
         alternarEspelhamentoVertical(elemento);
-        return;
     }
 }


### PR DESCRIPTION
## Descrição

Esta Pull Request implementa a ferramenta de criação de cubos 3D utilizando projeção isométrica no editor SVG. Também foram realizados ajustes para integrar o cubo às funcionalidades já existentes, como seleção, movimentação, histórico de ações, personalização de cores e remoção com a ferramenta borracha.

### Funcionalidades implementadas

* Estrutura para representação dos vértices e faces de um cubo em coordenadas 3D (x, y, z);
* Implementação da projeção isométrica para conversão das coordenadas 3D em coordenadas 2D;
* Renderização das faces utilizando elementos `<polygon>` do SVG;
* Ordenação das faces (Painter's Algorithm) e descarte de faces traseiras (*Back-face Culling*), evitando sobreposição incorreta;
* Ferramenta para criação de cubos 3D no editor;
* Suporte às cores de preenchimento e borda definidas pelo usuário;
* Integração com a seleção e movimentação de cubos;
* Suporte ao histórico de ações (Undo/Redo) durante criação e movimentação;
* Compatibilidade da ferramenta Borracha com cubos 3D.

### Critérios de aceite atendidos

- [X] Estrutura para armazenamento de vértices em três dimensões;

- [X] Função de projeção das coordenadas 3D para 2D;

- [X]  Ferramenta básica de criação de objeto tridimensional (cubo);

- [X] Renderização das faces utilizando <polygon>;

- [X] Ordenação das faces para garantir a visibilidade correta.

### Autores

Implementação desenvolvida em dupla por @Washington-Smith  e @rogeriobarbosaa.

Resolve a issue #108 @gustavoresque 
