### PR TITLE
179 feature cisalhamento skew 2d de elementos selecionados

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -341,6 +341,15 @@ body {
     stroke: white;
 }
 
+.skew-handle {
+    cursor: ew-resize;
+}
+
+.skew-handle:hover {
+    fill: #4a90d9; /* Inverte a cor ao passar o mouse */
+    stroke: white;
+}
+
 #zoom-options {
   position: absolute;
   background: var(--cor-fundo-barra);

--- a/js/core/Selecao.js
+++ b/js/core/Selecao.js
@@ -1,14 +1,18 @@
 import { criarElementoSVG, converterCoordenadaClienteParaSVG } from '../utils/svgHelpers.js';
 
 export class Selecao {
-  constructor(overlaySvg) {
+  constructor(overlaySvg, canvasSvg) {
     this.overlaySvg = overlaySvg;
+    this.canvasSvg = canvasSvg;
     this.bordaSelecao = null;
+    this.grupoAlcas = null;
+    this.alcaSkewX = null;
+    this.alcaSkewY = null;
   }
 
   /**
    * Desenha a borda de seleção ao redor do conjunto de elementos.
-   * @param {SVGElement[]} elementosSelecionados 
+   * @param {SVGElement[]} elementosSelecionados
    */
   desenhar(elementosSelecionados) {
     this.limpar();
@@ -29,11 +33,14 @@ export class Selecao {
       'pointer-events': 'none'
     });
     this.overlaySvg.appendChild(this.bordaSelecao);
+
+    this._criarAlcasSkew();
+    this._posicionarAlcasSkew(bounds);
   }
 
   /**
    * Atualiza a posição e dimensões da borda de seleção para múltiplos elementos.
-   * @param {SVGElement[]} elementosSelecionados 
+   * @param {SVGElement[]} elementosSelecionados
    */
   atualizarPosicao(elementosSelecionados) {
     if (this.bordaSelecao && elementosSelecionados && elementosSelecionados.length > 0) {
@@ -43,7 +50,77 @@ export class Selecao {
       this.bordaSelecao.setAttribute('y', String(bounds.minY - 2));
       this.bordaSelecao.setAttribute('width', String(bounds.maxX - bounds.minX + 4));
       this.bordaSelecao.setAttribute('height', String(bounds.maxY - bounds.minY + 4));
+
+      this._posicionarAlcasSkew(bounds);
     }
+  }
+
+  /**
+   * Expõe o cálculo de bounds unificados para uso externo (ex: SelecaoTool
+   * precisa do mesmo pivô/centro para calcular o cisalhamento).
+   * @param {SVGElement[]} elementos
+   */
+  obterBoundsSelecao(elementos) {
+    return this._calcularBoundsUnificados(elementos);
+  }
+
+  /**
+   * Cria (uma única vez) o grupo e as alças de cisalhamento (skew X e Y).
+   * Precisa viver dentro do #canvas real (não do overlay, que tem
+   * pointer-events:none e não recebe os listeners globais de mouse).
+   * @private
+   */
+  _criarAlcasSkew() {
+    if (this.alcaSkewX || !this.canvasSvg) return;
+
+    this.grupoAlcas = criarElementoSVG('g', {
+      id: 'selecao-alcas',
+      style: 'pointer-events: all;'
+    });
+
+    this.alcaSkewX = criarElementoSVG('rect', {
+      width: 8,
+      height: 8,
+      fill: 'white',
+      stroke: '#4a90d9',
+      'stroke-width': 1,
+      class: 'skew-handle',
+      style: 'cursor: ew-resize;'
+    });
+
+    this.alcaSkewY = criarElementoSVG('rect', {
+      width: 8,
+      height: 8,
+      fill: 'white',
+      stroke: '#4a90d9',
+      'stroke-width': 1,
+      class: 'skew-handle',
+      style: 'cursor: ns-resize;'
+    });
+
+    this.grupoAlcas.appendChild(this.alcaSkewX);
+    this.grupoAlcas.appendChild(this.alcaSkewY);
+    this.canvasSvg.appendChild(this.grupoAlcas);
+  }
+
+  /**
+   * Reposiciona as alças de skew: a de X centralizada no topo da borda,
+   * a de Y centralizada na lateral esquerda da borda.
+   * @private
+   */
+  _posicionarAlcasSkew(bounds) {
+    if (!this.alcaSkewX || !this.alcaSkewY) return;
+
+    const centroX = (bounds.minX + bounds.maxX) / 2;
+    const centroY = (bounds.minY + bounds.maxY) / 2;
+    const topoY = bounds.minY - 10;
+    const esquerdaX = bounds.minX - 10;
+
+    this.alcaSkewX.setAttribute('x', String(centroX - 4));
+    this.alcaSkewX.setAttribute('y', String(topoY - 4));
+
+    this.alcaSkewY.setAttribute('x', String(esquerdaX - 4));
+    this.alcaSkewY.setAttribute('y', String(centroY - 4));
   }
 
   /**
@@ -72,5 +149,12 @@ export class Selecao {
       this.bordaSelecao.parentNode.removeChild(this.bordaSelecao);
     }
     this.bordaSelecao = null;
+
+    if (this.grupoAlcas && this.grupoAlcas.parentNode) {
+      this.grupoAlcas.parentNode.removeChild(this.grupoAlcas);
+    }
+    this.grupoAlcas = null;
+    this.alcaSkewX = null;
+    this.alcaSkewY = null;
   }
 }

--- a/js/core/Selecao.js
+++ b/js/core/Selecao.js
@@ -1,9 +1,8 @@
 import { criarElementoSVG, converterCoordenadaClienteParaSVG } from '../utils/svgHelpers.js';
 
 export class Selecao {
-  constructor(overlaySvg, canvasSvg) {
+  constructor(overlaySvg) {
     this.overlaySvg = overlaySvg;
-    this.canvasSvg = canvasSvg;
     this.bordaSelecao = null;
     this.grupoAlcas = null;
     this.alcaSkewX = null;
@@ -66,12 +65,16 @@ export class Selecao {
 
   /**
    * Cria (uma única vez) o grupo e as alças de cisalhamento (skew X e Y).
-   * Precisa viver dentro do #canvas real (não do overlay, que tem
-   * pointer-events:none e não recebe os listeners globais de mouse).
+   * Precisa viver no overlay (não no #canvas real): o #canvas é fotografado
+   * inteiro pelo HistoryManager a cada ação (svgCanvas.innerHTML), então
+   * qualquer elemento de UI colocado lá acaba "gravado" no undo/redo e vira
+   * órfão quando o innerHTML é substituído. As alças só recebem clique porque
+   * o grupo tem pointer-events:all, mesmo o overlay como um todo tendo
+   * pointer-events:none (ver main.js).
    * @private
    */
   _criarAlcasSkew() {
-    if (this.alcaSkewX || !this.canvasSvg) return;
+    if (this.alcaSkewX) return;
 
     this.grupoAlcas = criarElementoSVG('g', {
       id: 'selecao-alcas',
@@ -100,7 +103,7 @@ export class Selecao {
 
     this.grupoAlcas.appendChild(this.alcaSkewX);
     this.grupoAlcas.appendChild(this.alcaSkewY);
-    this.canvasSvg.appendChild(this.grupoAlcas);
+    this.overlaySvg.appendChild(this.grupoAlcas);
   }
 
   /**

--- a/js/main.js
+++ b/js/main.js
@@ -161,7 +161,7 @@ const observer = new MutationObserver((mutations) => {
 observer.observe(svgCanvas, { attributes: true, attributeFilter: ['viewBox'] });
 
 // Inicializar a classe de seleção visual
-const selecaoVisual = new Selecao(overlayCanvas, svgCanvas);
+const selecaoVisual = new Selecao(overlayCanvas);
 definirGerenciadorSelecao(selecaoVisual);
 
 // Instâncias das ferramentas disponíveis com todas as implementações da main
@@ -263,6 +263,27 @@ svgCanvas.addEventListener('mousedown', (evento) => {
 svgCanvas.addEventListener('mousemove', (evento) => {
   if (estado.ferramentaAtual) {
     estado.ferramentaAtual.onMouseMove(evento);
+  }
+});
+
+// O overlay tem pointer-events:none (para não bloquear cliques no canvas),
+// exceto nos elementos de UI que o próprio Selecao habilita explicitamente
+// (ex: alças de skew) — por isso precisa dos mesmos listeners delegados.
+overlayCanvas.addEventListener('mousedown', (evento) => {
+  if (estado.ferramentaAtual) {
+    estado.ferramentaAtual.onMouseDown(evento);
+  }
+});
+
+overlayCanvas.addEventListener('mousemove', (evento) => {
+  if (estado.ferramentaAtual) {
+    estado.ferramentaAtual.onMouseMove(evento);
+  }
+});
+
+overlayCanvas.addEventListener('mouseup', (evento) => {
+  if (estado.ferramentaAtual) {
+    estado.ferramentaAtual.onMouseUp(evento);
   }
 });
 

--- a/js/main.js
+++ b/js/main.js
@@ -161,13 +161,13 @@ const observer = new MutationObserver((mutations) => {
 observer.observe(svgCanvas, { attributes: true, attributeFilter: ['viewBox'] });
 
 // Inicializar a classe de seleção visual
-const selecaoVisual = new Selecao(overlayCanvas);
+const selecaoVisual = new Selecao(overlayCanvas, svgCanvas);
 definirGerenciadorSelecao(selecaoVisual);
 
 // Instâncias das ferramentas disponíveis com todas as implementações da main
 const cameraGlobal = new CameraSVG([svgCanvas, overlayCanvas]);
 const instanciasFerramentas = {
-  selecao: new SelecaoTool(svgCanvas),
+  selecao: new SelecaoTool(svgCanvas, selecaoVisual),
   edicaoVertices: new NodeEditTool(svgCanvas),
   retangulo: new RetanguloTool(svgCanvas),
   linha: new LinhaTool(svgCanvas),

--- a/js/tools/SelecaoTool.js
+++ b/js/tools/SelecaoTool.js
@@ -13,13 +13,17 @@ import {
  * Ferramenta de Seleção
  */
 export class SelecaoTool extends ToolBase {
-  constructor(svgCanvas) {
+  constructor(svgCanvas, selecaoVisual) {
     super();
     this.svgCanvas = svgCanvas;
+    this.selecaoVisual = selecaoVisual;
 
     this.isDragging = false;
     this.offsets = [];
     this.estadoInicialMovimento = null;
+
+    this.isSkewing = false;
+    this.skewInicial = null;
   }
 
   /**
@@ -53,20 +57,136 @@ export class SelecaoTool extends ToolBase {
       }
     }
 
-    // Se não existir, cria a propriedade Translate na matriz do elemento
+    // Se não existir, cria a propriedade Translate na matriz do elemento.
+    // Precisa ser inserida SEMPRE como o item mais externo (índice 0): se já
+    // existir uma matriz de skew (aplicada primeiro, sobre a geometria local),
+    // a translação tem que ser aplicada por último, ou o cisalhamento passa a
+    // reagir à posição arrastada, deslocando a forma de forma espúria.
     if (!translateItem) {
       const svgRef = el.ownerSVGElement || this.svgCanvas;
       translateItem = svgRef.createSVGTransform();
       translateItem.setTranslate(x, y);
-      transformList.appendItem(translateItem);
+      transformList.insertItemBefore(translateItem, 0);
     } else {
       translateItem.setTranslate(x, y);
     }
   }
 
+  /**
+   * Lê a matriz de cisalhamento (skew) atual do elemento, se houver.
+   * @private
+   */
+  _obterMatrizSkew(el) {
+    const transformList = el.transform.baseVal;
+    for (let i = 0; i < transformList.numberOfItems; i++) {
+      const item = transformList.getItem(i);
+      if (item.type === SVGTransform.SVG_TRANSFORM_MATRIX) {
+        return item;
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Aplica (ou atualiza) a matriz de cisalhamento combinada (X e Y) do
+   * elemento, pivotada em `(cxLocal, cyLocal)` para que esse ponto não se
+   * desloque visualmente. `kX` cisalha horizontalmente (varia com Y), `kY`
+   * cisalha verticalmente (varia com X) — os dois convivem na mesma matriz.
+   * @private
+   */
+  _aplicarSkewMatriz(el, kX, kY, cxLocal, cyLocal) {
+    const transformList = el.transform.baseVal;
+    const svgRef = el.ownerSVGElement || this.svgCanvas;
+    let skewItem = this._obterMatrizSkew(el);
+
+    if (!skewItem) {
+      skewItem = svgRef.createSVGTransform();
+      transformList.appendItem(skewItem);
+    }
+
+    const matriz = Object.assign(svgRef.createSVGMatrix(), {
+      a: 1, b: kY, c: kX, d: 1, e: -kX * cyLocal, f: -kY * cxLocal
+    });
+    skewItem.setMatrix(matriz);
+  }
+
+  /**
+   * Corrige o pivô de uma matriz de skew já existente após um arrasto que
+   * mexeu diretamente em x/y/cx/cy (rect, circle, ellipse, text, image, line).
+   * Esses elementos não têm uma translação nativa separada — arrastar move a
+   * própria geometria local, então os termos `e`/`f` da matriz precisam se
+   * mover junto para o cisalhamento continuar pivotado no mesmo ponto do
+   * desenho.
+   * @private
+   */
+  _ajustarSkewAoTransladar(el, dx, dy) {
+    if (!dx && !dy) return;
+    const skewItem = this._obterMatrizSkew(el);
+    if (!skewItem) return;
+
+    const svgRef = el.ownerSVGElement || this.svgCanvas;
+    const m = skewItem.matrix;
+    const matriz = Object.assign(svgRef.createSVGMatrix(), {
+      a: 1, b: m.b, c: m.c, d: 1,
+      e: m.e - m.c * dy,
+      f: m.f - m.b * dx
+    });
+    skewItem.setMatrix(matriz);
+  }
+
+  /**
+   * Inicia o cisalhamento (skew) a partir do arraste de uma das alças
+   * próprias. Usa o mesmo centro (pivô) para todos os elementos
+   * selecionados, para que a seleção cisalhe como um bloco rígido único, e
+   * soma incrementalmente a um `k` inicial (caso o elemento já tenha sido
+   * cisalhado antes nesse mesmo eixo).
+   * @param {{x:number,y:number}} pt
+   * @param {'x'|'y'} eixo
+   * @private
+   */
+  _iniciarSkew(pt, eixo) {
+    const bounds = this.selecaoVisual.obterBoundsSelecao(estado.elementosSelecionados);
+    const cySelecao = (bounds.minY + bounds.maxY) / 2;
+    const cxSelecao = (bounds.minX + bounds.maxX) / 2;
+
+    this.skewInicial = {
+      eixo,
+      mouseInicial: eixo === 'x' ? pt.x : pt.y,
+      denom: eixo === 'x' ? (bounds.minY - cySelecao) : (bounds.minX - cxSelecao),
+      elementos: estado.elementosSelecionados.map(el => {
+        const skewItem = this._obterMatrizSkew(el);
+        const kXInicial = skewItem ? skewItem.matrix.c : 0;
+        const kYInicial = skewItem ? skewItem.matrix.b : 0;
+        const translacao = this._obterTranslacao(el);
+        return {
+          el,
+          kXInicial,
+          kYInicial,
+          cxLocal: cxSelecao - translacao.x,
+          cyLocal: cySelecao - translacao.y
+        };
+      })
+    };
+    this.isSkewing = true;
+  }
+
   onMouseDown(evento) {
-    const pt = obterCoordenadaSVG(evento, this.svgCanvas);
     const target = evento.target;
+
+    // Alças de cisalhamento têm prioridade: sem isso, um <rect class="skew-handle">
+    // seria confundido com uma forma arrastável pelo bloco abaixo.
+    if (this.selecaoVisual && estado.elementosSelecionados.length > 0) {
+      if (target === this.selecaoVisual.alcaSkewX) {
+        this._iniciarSkew(obterCoordenadaSVG(evento, this.svgCanvas), 'x');
+        return;
+      }
+      if (target === this.selecaoVisual.alcaSkewY) {
+        this._iniciarSkew(obterCoordenadaSVG(evento, this.svgCanvas), 'y');
+        return;
+      }
+    }
+
+    const pt = obterCoordenadaSVG(evento, this.svgCanvas);
     const isShift = evento.shiftKey;
 
     const allowedTags = ['rect', 'text', 'image', 'circle', 'ellipse', 'g', 'path', 'line', 'lapis'];
@@ -102,6 +222,11 @@ export class SelecaoTool extends ToolBase {
   }
 
   onMouseMove(evento) {
+    if (this.isSkewing) {
+      this._aplicarSkew(evento);
+      return;
+    }
+
     if (!this.isDragging || estado.elementosSelecionados.length === 0) return;
 
     const pt = obterCoordenadaSVG(evento, this.svgCanvas);
@@ -117,11 +242,17 @@ export class SelecaoTool extends ToolBase {
 
       // Atualiza coordenadas baseado no tipo de elemento
       if (tag === 'rect' || tag === 'text' || tag === 'image') {
+        const dxAnterior = novoX - parseFloat(el.getAttribute('x') || 0);
+        const dyAnterior = novoY - parseFloat(el.getAttribute('y') || 0);
         el.setAttribute('x', String(novoX));
         el.setAttribute('y', String(novoY));
+        this._ajustarSkewAoTransladar(el, dxAnterior, dyAnterior);
       } else if (tag === 'circle' || tag === 'ellipse') {
+        const dxAnterior = novoX - parseFloat(el.getAttribute('cx') || 0);
+        const dyAnterior = novoY - parseFloat(el.getAttribute('cy') || 0);
         el.setAttribute('cx', String(novoX));
         el.setAttribute('cy', String(novoY));
+        this._ajustarSkewAoTransladar(el, dxAnterior, dyAnterior);
       } else if (tag === 'line') {
           // Exemplo simplificado para linha (move mantendo comprimento)
           const dx = novoX - parseFloat(el.getAttribute('x1') || 0);
@@ -130,6 +261,7 @@ export class SelecaoTool extends ToolBase {
           el.setAttribute('y1', String(novoY));
           el.setAttribute('x2', String(parseFloat(el.getAttribute('x2') || 0) + dx));
           el.setAttribute('y2', String(parseFloat(el.getAttribute('y2') || 0) + dy));
+          this._ajustarSkewAoTransladar(el, dx, dy);
       } else if (tag === 'path' || tag === 'g') {
         // Aplica a translação nativa em vez de escrever string template
         this._definirTranslacao(el, novoX, novoY);
@@ -139,7 +271,41 @@ export class SelecaoTool extends ToolBase {
     atualizarPosicaoSelecaoVisual();
   }
 
+  /**
+   * @private
+   */
+  _aplicarSkew(evento) {
+    if (!this.skewInicial || this.skewInicial.denom === 0) return;
+
+    const pt = obterCoordenadaSVG(evento, this.svgCanvas);
+    const posicaoAtual = this.skewInicial.eixo === 'x' ? pt.x : pt.y;
+    const incremento = (posicaoAtual - this.skewInicial.mouseInicial) / this.skewInicial.denom;
+
+    this.skewInicial.elementos.forEach(({ el, kXInicial, kYInicial, cxLocal, cyLocal }) => {
+      const kX = this.skewInicial.eixo === 'x' ? kXInicial + incremento : kXInicial;
+      const kY = this.skewInicial.eixo === 'y' ? kYInicial + incremento : kYInicial;
+      this._aplicarSkewMatriz(el, kX, kY, cxLocal, cyLocal);
+    });
+
+    atualizarPosicaoSelecaoVisual();
+  }
+
   onMouseUp(evento) {
+    if (this.isSkewing) {
+      const houveSkew = this.skewInicial && this.skewInicial.elementos.some(({ el, kXInicial, kYInicial }) => {
+        const skewItem = this._obterMatrizSkew(el);
+        const kXFinal = skewItem ? skewItem.matrix.c : 0;
+        const kYFinal = skewItem ? skewItem.matrix.b : 0;
+        return kXFinal !== kXInicial || kYFinal !== kYInicial;
+      });
+      if (houveSkew) {
+        registrarAcaoHistorico();
+      }
+      this.isSkewing = false;
+      this.skewInicial = null;
+      return;
+    }
+
     if (this.isDragging) {
       const houveMovimento = this._houveMovimentoReal();
       if (houveMovimento) {
@@ -183,6 +349,8 @@ export class SelecaoTool extends ToolBase {
     this.isDragging = false;
     this.offsets = [];
     this.estadoInicialMovimento = null;
+    this.isSkewing = false;
+    this.skewInicial = null;
     definirElementosSelecionados([]);
   }
 


### PR DESCRIPTION
Closes #179

## O que foi implementado

- Duas alças próprias na borda de seleção (`Selecao.js`): uma no topo-centro para skew horizontal (X), outra na lateral esquerda para skew vertical (Y).
- Arrastar qualquer uma das alças aplica uma matriz de cisalhamento combinada (`matrix(1, kY, kX, 1, e, f)`) via `transform`, pivotada no **centro do bounding box da seleção** — o ponto central não se desloca visualmente, resolvendo o problema clássico de cisalhar em torno da origem `(0,0)` em vez do centro da figura.
- Suporte a multi-seleção: todos os elementos selecionados cisalham como um bloco rígido único (mesmo pivô e mesmo `k`).
- Undo/redo via `registrarAcaoHistorico()` (mesmo mecanismo já usado pelas outras ferramentas).
- Correção de um bug de ordering no transform de translação (`_definirTranslacao`): agora a translação é sempre inserida como o item mais externo da lista, para não conflitar com uma matriz de skew já aplicada.
- Correção de um bug encontrado durante os testes: as alças viviam inicialmente dentro do `#canvas` real (necessário para receberem eventos de mouse), mas isso fazia o `HistoryManager` gravá-las no snapshot do histórico (`svgCanvas.innerHTML`), deixando alças "órfãs" na tela depois de um Ctrl+Z. Corrigido movendo as alças para o `#overlay-canvas` (como a borda de seleção sempre esteve) e adicionando os listeners de mouse também no overlay.

## Bug encontrado, não corrigido nesta PR

A ferramenta de **Polígono/Polilinha** não permite selecionar os elementos que cria: `allowedTags` em `SelecaoTool.js` nunca incluiu `'polygon'`/`'polyline'`, então cliques nesses elementos nunca são reconhecidos por `_buscarElementoValido`. É um bug pré-existente (não introduzido por esta PR), fora do escopo do cisalhamento. 

## Solicitação de badges

🐛 **Bug Catcher** — durante os testes encontrei e corrigi um bug sutil: as alças de skew inicialmente viviam dentro do `#canvas` real, mas o `HistoryManager` fotografa `svgCanvas.innerHTML` a cada ação, então as alças acabavam gravadas no histórico. Um Ctrl+Z depois de um skew deixava alças "órfãs" na tela, desconectadas da classe `Selecao`. Resolvido movendo-as para o `#overlay-canvas` (como a borda de seleção sempre esteve) e replicando os listeners de mouse lá.

🧠 **Lógica Brilhante** — o cisalhamento não podia simplesmente aplicar `matrix(1,0,tan(θ),1,0,0)` cru, porque isso cisalha em torno da origem `(0,0)` e não do centro da figura, deslocando o desenho como se fosse uma translação indesejada. A solução pivota a matriz no centro do bounding box da seleção (`e = -kX·cy`, `f = -kY·cx`), garantindo que esse ponto fique matematicamente invariante para qualquer `k` — inclusive quando o elemento já tem uma translação ou um skew anterior aplicado.

💻 **Enter the Matrix** — toda a feature é manipulação direta de `SVGTransform`/matriz (não `skewX()`/`skewY()` prontos do CSS): composição de matriz combinada X+Y numa única `matrix()`, correção de ordem entre os transforms de translação e cisalhamento, e ajuste incremental do pivô quando um elemento cisalhado é arrastado depois.
