### PR TITLE
194 feature adicionar controle de espessura do lapis

### DIFF
--- a/index.html
+++ b/index.html
@@ -328,13 +328,12 @@
 
                     <div id="tab-camadas" class="tab-content"></div>
                 </div>
-                <label>
-            
+                <label> Espessura do Lápis: 
             <input
                 type="range"
                 id="espessura-lapis"
                 min="1"
-                max="20"
+                max="100"
                 value="2">
 
             <span id="valor-espessura-lapis">2</span> px

--- a/index.html
+++ b/index.html
@@ -328,7 +328,18 @@
 
                     <div id="tab-camadas" class="tab-content"></div>
                 </div>
-            </aside>
+                <label>
+            
+            <input
+                type="range"
+                id="espessura-lapis"
+                min="1"
+                max="20"
+                value="2">
+
+            <span id="valor-espessura-lapis">2</span> px
+        </label>
+                </aside>
         </div><!-- /#workspace -->
     </div><!-- /#app -->
 

--- a/js/core/StateManager.js
+++ b/js/core/StateManager.js
@@ -21,9 +21,15 @@ export const estado = {
   estiloLinha: 'continua',
   interfaceAtual: 'inicio', // Nova flag para sabermos onde o usuário está
   elementosSelecionados: [],
+  espessuraLapis: 2,
 };
 
 let gerenciadorSelecaoVisual = null;
+
+
+export function definirEspessuraLapis(espessura) {
+  estado.espessuraLapis = Number(espessura);
+}
 
 export function definirGerenciadorSelecao(selecao) {
   gerenciadorSelecaoVisual = selecao;

--- a/js/main.js
+++ b/js/main.js
@@ -67,6 +67,7 @@ const botoesEstiloLinha = document.querySelectorAll('.btn-line-style');
 const nomeFerramenta = document.getElementById('nome-ferramenta');
 const btnExportar = document.getElementById('btn-exportar');
 const exportFormat = document.getElementById('export-format');
+const inputEspessuraLapis =  document.getElementById("espessura-lapis");
 
 // Botões de histórico
 const btnDesfazer = document.getElementById('btn-desfazer');
@@ -311,6 +312,14 @@ atualizarBotaoEstiloLinhaAtivo(estado.estiloLinha);
 btnExportar.addEventListener('click', () => {
   const formato = exportFormat.value || 'png';
   exportarDesenho(svgCanvas, formato);
+});
+
+const valorEspessura =
+    document.getElementById("valor-espessura-lapis");
+
+inputEspessuraLapis.addEventListener("input", (e) => {
+    definirEspessuraLapis(e.target.value);
+    valorEspessura.textContent = e.target.value;
 });
 
 // --- Controle de Camadas (Z-Index) ---

--- a/js/main.js
+++ b/js/main.js
@@ -39,6 +39,7 @@ import { duplicarElemento } from './utils/duplicateHelpers.js';
 import { PoligonoPolilinhaTool } from './tools/PoligonoPolilinhaTool.js';
 import { SideBar } from './core/SideBar.js';
 import { PincelTool } from './tools/PincelTool.js';
+import {definirEspessuraLapis} from "./core/StateManager.js";
 import { CameraSVG } from './core/CameraSVG.js';
 import { obterCoordenadaSVG } from './utils/svgHelpers.js';
 import { HistoryManager } from './core/HistoryManager.js';

--- a/js/tools/LapisTool.js
+++ b/js/tools/LapisTool.js
@@ -24,7 +24,7 @@ export class Lapis extends ToolBase {
         this.path = criarElementoSVG("path", {
             d: this.d,
             stroke: estado?.corBorda || "black",
-            "stroke-width": 2,
+            "stroke-width": estado.espessuraLapis,
             fill: "none",
             "stroke-linecap": "round",
             "stroke-linejoin": "round"


### PR DESCRIPTION
# Descrição

Implementado um controle de espessura para a ferramenta Lápis, permitindo que o usuário personalize a largura do traçado antes de iniciar um desenho. A espessura selecionada passa a ser utilizada imediatamente na criação de novos traçados, enquanto os desenhos já existentes preservam sua configuração original.

A funcionalidade foi integrada ao painel de propriedades, seguindo o padrão de personalização já existente na aplicação.

## Critérios de aceitação atendidos

- [X] Adicionado um controle de espessura para a ferramenta Lápis.
- [X] Permitida a configuração de diferentes valores de largura do traço.
- [X] Os novos desenhos utilizam imediatamente a espessura selecionada.
- [X] Cada traçado mantém sua espessura individual após sua criação.

## Alterações realizadas

* Adicionado o estado global para armazenar a espessura atual da ferramenta Lápis.
* Atualizada a ferramenta Lápis para utilizar a espessura configurada ao criar novos traçados.
* Incluído um controle de espessura no painel de propriedades.
* Integrado o controle da interface ao estado da aplicação para atualização em tempo real.

@gustavoresque 