### PR TITLE
[Feature]: Implementação da Edição de Vértices na Linha Curvada

### DIFF
--- a/js/core/HistoryManager.js
+++ b/js/core/HistoryManager.js
@@ -1,4 +1,5 @@
 import { definirElementosSelecionados } from '../core/StateManager.js';
+import { estado } from '../core/StateManager.js';
 import { MementoSVG } from './MementoSVG.js';
 
 export class HistoryManager {
@@ -18,7 +19,7 @@ export class HistoryManager {
     this.#redoStack = [];
 
     // Tira a "foto" do HTML interno atual do canvas
-    const snapshot = new MementoSVG(this.#svgCanvas.innerHTML);
+    const snapshot = new MementoSVG(this.#obterConteudoSvgLimpo());
 
     // Guarda na pilha principal
     this.#undoStack.push(snapshot);
@@ -76,5 +77,26 @@ export class HistoryManager {
   #aplicarEstado(conteudoSvg) {
     definirElementosSelecionados(null);
     this.#svgCanvas.innerHTML = conteudoSvg;
+    this.#removerOverlaysEdicao();
+    this.#limparEstadoFerramentaAtiva();
+  }
+
+  #obterConteudoSvgLimpo() {
+    const containerTemporario = document.createElement('div');
+    containerTemporario.innerHTML = this.#svgCanvas.innerHTML;
+    this.#removerOverlaysEdicao(containerTemporario);
+    return containerTemporario.innerHTML;
+  }
+
+  #removerOverlaysEdicao(raiz = this.#svgCanvas) {
+    raiz.querySelectorAll('.overlay-handles, #overlay-nodes').forEach((elemento) => {
+      elemento.remove();
+    });
+  }
+
+  #limparEstadoFerramentaAtiva() {
+    if (estado.ferramentaAtual && typeof estado.ferramentaAtual.limparSelecao === 'function') {
+      estado.ferramentaAtual.limparSelecao();
+    }
   }
 }

--- a/js/shape/LinhaCurvadaShape.js
+++ b/js/shape/LinhaCurvadaShape.js
@@ -1,0 +1,95 @@
+import { ShapeBase } from './ShapeBase.js';
+import { gerarPathDataSuave } from '../utils/curvaHelpers.js';
+
+/**
+ * LinhaCurvadaShape
+ *
+ * Responsável por exibir e permitir a edição dos vértices (nós) de um
+ * <path> criado pela LinhaCurvadaTool. Segue o mesmo "contrato" usado pelo
+ * NodeEditTool para RetanguloShape/ElipseShape
+ */
+export class LinhaCurvadaShape extends ShapeBase {
+  constructor(svgCanvas) {
+    super(svgCanvas);
+    this.pontos = [];
+  }
+
+  inicializarOverlay() {
+    if (this.grupoOverlay) return;
+
+    super.inicializarOverlay();
+    this.grupoOverlay.classList.add('overlay-handles', 'overlay-linha-curvada');
+  }
+
+  /**
+   * Lê os vértices salvos em data-pontos e desenha um handle (quadrado) para
+   * cada um deles, seguindo o mesmo padrão visual usado nas outras shapes.
+   */
+  renderizarTodosHandles(elementoAlvo) {
+    if (!this.grupoOverlay) this.inicializarOverlay();
+
+    this.pontos = this.obterPontosDoElemento(elementoAlvo);
+    this.grupoOverlay.innerHTML = '';
+
+    this.pontos.forEach((ponto, indice) => {
+      this.renderizarHandle({
+        x: ponto.x,
+        y: ponto.y,
+        id: String(indice),
+      });
+    });
+  }
+
+  /**
+   * Move visualmente o handle ativo para acompanhar o mouse. Como o handle
+   * é um <rect>, posicionamos pelo canto superior esquerdo (x/y), então
+   * precisamos recentralizar em relação ao lado do quadrado.
+   */
+  atualizarPosicaoHandle(coordenadas) {
+    super.atualizarPosicaoHandle(coordenadas);
+  }
+
+  /**
+   * Atualiza o vértice movido, regenera o `d` do path com o mesmo algoritmo
+   * de suavização usado no desenho, e persiste os novos vértices de volta
+   * no elemento.
+   */
+  atualizarForma(coordenadas, elementoAlvo, activeNodeId) {
+    const indice = Number(activeNodeId);
+    if (Number.isNaN(indice) || !this.pontos[indice]) return;
+
+    this.pontos[indice] = { x: coordenadas.x, y: coordenadas.y };
+
+    const novoPathData = gerarPathDataSuave(this.pontos);
+    elementoAlvo.setAttribute('d', novoPathData);
+    elementoAlvo.dataset.pontos = JSON.stringify(this.pontos);
+
+    this.sincronizarTodosOsHandles();
+  }
+
+  removeOverlay() {
+    super.removeOverlay();
+    this.pontos = [];
+  }
+
+  sincronizarTodosOsHandles() {
+    if (!this.grupoOverlay) return;
+
+    this.pontos.forEach((ponto, indice) => {
+      const handle = this.grupoOverlay.querySelector(`[data-node-id="${String(indice)}"]`);
+      if (!handle) return;
+
+      handle.setAttribute('x', ponto.x - 4);
+      handle.setAttribute('y', ponto.y - 4);
+    });
+  }
+
+  obterPontosDoElemento(elementoAlvo) {
+    try {
+      const pontosSalvos = JSON.parse(elementoAlvo.dataset.pontos || '[]');
+      return Array.isArray(pontosSalvos) ? pontosSalvos : [];
+    } catch (erro) {
+      return [];
+    }
+  }
+}

--- a/js/tools/LinhaCurvadaTool.js
+++ b/js/tools/LinhaCurvadaTool.js
@@ -1,6 +1,7 @@
 import { ToolBase } from './ToolBase.js';
 import { criarElementoSVG, obterCoordenadaSVG } from '../utils/svgHelpers.js';
 import { estado, registrarAcaoHistorico } from '../core/StateManager.js';
+import { gerarPathDataSuave } from '../utils/curvaHelpers.js';
 
 const ESTILOS_LINHA_CURVADA = {
   continua: {},
@@ -104,10 +105,16 @@ export class LinhaCurvadaTool extends ToolBase {
     }
 
     this.atualizarPath(pontoFinal);
+    this.salvarVerticesNoElemento(this.pathElement, pontosFinais);
     this.pathElement = null;
     this.pontos = [];
     this.ultimoPontoMouse = null;
     registrarAcaoHistorico();
+  }
+
+  salvarVerticesNoElemento(elemento, pontos) {
+    elemento.dataset.tipoLinha = 'linhaCurvada';
+    elemento.dataset.pontos = JSON.stringify(pontos);
   }
 
   resetarDesenho() {
@@ -122,39 +129,7 @@ export class LinhaCurvadaTool extends ToolBase {
 
   criarPathData(pontoPreview = null) {
     const pontosPath = this.montarPontosPath(pontoPreview);
-
-    if (pontosPath.length === 0) return '';
-
-    const [inicio] = pontosPath;
-
-    if (pontosPath.length === 1) {
-      return `M ${inicio.x} ${inicio.y}`;
-    }
-
-    if (pontosPath.length === 2) {
-      const fim = pontosPath[1];
-      return `M ${inicio.x} ${inicio.y} L ${fim.x} ${fim.y}`;
-    }
-
-    let d = `M ${inicio.x} ${inicio.y}`;
-
-    for (let i = 1; i < pontosPath.length - 1; i += 1) {
-      const controle = pontosPath[i];
-      const proximo = pontosPath[i + 1];
-      const ehUltimoControle = i === pontosPath.length - 2;
-      const fim = ehUltimoControle ? proximo : this.calcularPontoMedio(controle, proximo);
-
-      d += ` Q ${controle.x} ${controle.y} ${fim.x} ${fim.y}`;
-    }
-
-    return d;
-  }
-
-  calcularPontoMedio(pontoA, pontoB) {
-    return {
-      x: (pontoA.x + pontoB.x) / 2,
-      y: (pontoA.y + pontoB.y) / 2,
-    };
+    return gerarPathDataSuave(pontosPath);
   }
 
   montarPontosPath(pontoExtra = null) {

--- a/js/tools/NodeEditTool.js
+++ b/js/tools/NodeEditTool.js
@@ -1,7 +1,9 @@
 import { ToolBase } from './ToolBase.js';
-import { obterCoordenadaSVG, criarElementoSVG } from '../utils/svgHelpers.js';
+import { obterCoordenadaSVG } from '../utils/svgHelpers.js';
 import { RetanguloShape } from '../shape/RetanguloShape.js';
 import { ElipseShape } from '../shape/ElipseShape.js';
+import { LinhaCurvadaShape } from '../shape/LinhaCurvadaShape.js';
+import { registrarAcaoHistorico } from '../core/StateManager.js';
 
 /**
  * NodeEditTool
@@ -20,21 +22,37 @@ export class NodeEditTool extends ToolBase {
             'rect': new RetanguloShape(svgCanvas),
             'ellipse': new ElipseShape(svgCanvas),
             'image': new RetanguloShape(svgCanvas), // Image possui as mesmas propriedades de retangulos
+            'linhaCurvada': new LinhaCurvadaShape(svgCanvas),
         }
+    }
+
+    obterTipoEditavel(elemento) {
+        if (!elemento || !elemento.tagName) return null;
+
+        const tag = elemento.tagName.toLowerCase();
+
+        if (tag === 'path') {
+            return elemento.dataset && elemento.dataset.tipoLinha === 'linhaCurvada'
+                ? 'linhaCurvada'
+                : null;
+        }
+
+        return Object.prototype.hasOwnProperty.call(this.allowedShapes, tag) ? tag : null;
     }
 
     /**
      * Executado ao clicar em um elemento.
      */
     onMouseDown(evento) {
-        const pt = obterCoordenadaSVG(evento, this.svgCanvas);
         const target = evento.target;
-        let shape = this.elementoAlvo ? this.allowedShapes[this.elementoAlvo.tagName] : null;
+        const tipoAtual = this.elementoAlvo ? this.obterTipoEditavel(this.elementoAlvo) : null;
+        let shape = tipoAtual ? this.allowedShapes[tipoAtual] : null;
 
         // Verifica se o clique foi em um handle de nó
         if (shape && shape.grupoOverlay && shape.grupoOverlay.contains(target)) {
             this.isDraggingNode = true;
             this.activeNodeId = target.getAttribute('data-node-id');
+            shape.activeNodeId = this.activeNodeId;
             
             // Impede que o evento selecione outros elementos abaixo
             evento.stopPropagation();
@@ -42,14 +60,14 @@ export class NodeEditTool extends ToolBase {
         }
 
         this.limparSelecao();
-        const tag = target.tagName ? target.tagName.toLowerCase() : '';
-        let newShape = this.allowedShapes[tag];
+        const tipo = this.obterTipoEditavel(target);
+        let newShape = tipo ? this.allowedShapes[tipo] : null;
 
         // Se o clique não foi no canvas vazio e for um elemento permitido
         if (
             target !== this.svgCanvas &&
             target.parentNode === this.svgCanvas &&
-            Object.keys(this.allowedShapes).includes(tag)
+            tipo
         ) {
             // Verifica se há algo selecionado no estado global
             this.elementoAlvo = target;
@@ -67,17 +85,23 @@ export class NodeEditTool extends ToolBase {
 
         const coordenadas = obterCoordenadaSVG(evento, this.svgCanvas);
 
-        // No onMouseMove de NodeEditTool.js altere para:
-        const tag = this.elementoAlvo.tagName.toLowerCase();
-        const shape = this.allowedShapes[tag];
+        const tipo = this.obterTipoEditavel(this.elementoAlvo);
+        const shape = this.allowedShapes[tipo];
+        shape.activeNodeId = this.activeNodeId;
         shape.atualizarPosicaoHandle(coordenadas);
         shape.atualizarForma(coordenadas, this.elementoAlvo, this.activeNodeId);
     }
 
-    //Finaliza o arraste
+    //Finaliza o arraste e salva o estado da edição (Memento) via HistoryManager
     onMouseUp() {
+        const estavaEditandoNo = this.isDraggingNode;
+
         this.isDraggingNode = false;
         this.activeNodeId = null;
+
+        if (estavaEditandoNo) {
+            registrarAcaoHistorico();
+        }
     }
 
     // Limpa os elementos de interface ao trocar de ferramenta.
@@ -86,8 +110,8 @@ export class NodeEditTool extends ToolBase {
     }
 
     limparSelecao() {
-        const tag = this.elementoAlvo ? this.elementoAlvo.tagName : '';
-        if (tag) this.allowedShapes[tag].removeOverlay();
+        const tipo = this.elementoAlvo ? this.obterTipoEditavel(this.elementoAlvo) : null;
+        if (tipo) this.allowedShapes[tipo].removeOverlay();
         this.elementoAlvo = null;
       }
     

--- a/js/utils/curvaHelpers.js
+++ b/js/utils/curvaHelpers.js
@@ -1,0 +1,43 @@
+/**
+ * curvaHelpers.js
+ *
+ * Lógica de geração do atributo `d` de um <path> suavizado a partir de uma
+ * lista de vértices. Extraído de LinhaCurvadaTool para ser reutilizado
+ * também na edição de vértices (LinhaCurvadaShape), garantindo que desenhar
+ * e editar produzam exatamente a mesma curva.
+ */
+
+export function gerarPathDataSuave(pontos) {
+  if (!pontos || pontos.length === 0) return '';
+
+  const [inicio] = pontos;
+
+  if (pontos.length === 1) {
+    return `M ${inicio.x} ${inicio.y}`;
+  }
+
+  if (pontos.length === 2) {
+    const fim = pontos[1];
+    return `M ${inicio.x} ${inicio.y} L ${fim.x} ${fim.y}`;
+  }
+
+  let d = `M ${inicio.x} ${inicio.y}`;
+
+  for (let i = 1; i < pontos.length - 1; i += 1) {
+    const controle = pontos[i];
+    const proximo = pontos[i + 1];
+    const ehUltimoControle = i === pontos.length - 2;
+    const fim = ehUltimoControle ? proximo : calcularPontoMedio(controle, proximo);
+
+    d += ` Q ${controle.x} ${controle.y} ${fim.x} ${fim.y}`;
+  }
+
+  return d;
+}
+
+export function calcularPontoMedio(pontoA, pontoB) {
+  return {
+    x: (pontoA.x + pontoB.x) / 2,
+    y: (pontoA.y + pontoB.y) / 2,
+  };
+}


### PR DESCRIPTION
### Descrição

Esta PR da issue #198 implementa a edição de vértices para a tool de Linha Curvada, onde, com as novas funcionalidades, é possível selecionar a ferramenta de edição de vértices, depois selecionar uma linha curvada desenhada no Canvas, e então editar os vértices dela.

### Critérios de Aceite Satisfeitos

- [X] É possível desenhar uma linha curvada no SVG
- [X] No momento da edição. o SVG salva os vértices que foram criados durante esse momento
- [X] A partir dos vértices salvos, ao selecionar a ferramenta de edição de vértices e depois clicar em uma linha curvada desenhada, os vértices salvos ficam disponíveis para edição
- [X] É possível salvar o estado das edições feitas nesses vértices (padrão Memento)

### Bônus

Com a implementação do Undo/Redo, salvando os estados a cada edição dos vértices de Linhas Curvadas, esta funcionalidade também foi aplicada por tabela em outras tools (como o Retângulo e a Elipse)

- Ou seja, o Undo/Redo (Memento) também salva os estados de outros elementos que tiveram seus vértices editados, adicionando uma nova funcionalidade para o código

### Alguns Testes Feitos

- Criação de linhas curvadas, retângulos e elipses
- Edição dos vértices nesses elementos (com os blocos de edição de vértices aparecendo na tela)
- Durante a edição de linhas curvadas e outros elementos, com os blocos de edição de vértices aparentes na tela, ao clicar em outro ponto da tela (que não seja o elemento) ou em outra tool, os blocos de edição desaparecem, não sendo possível editar novamente. Ou seja, o programa entende que a edição finalizou, sendo necessário clicar novamente na ferramenta de edição e depois clicar no elemento
- Desfazer e Refazer os estados desses elementos. Ao desfazer e refazer os estados, os blocos de edição de vértices não reaparecem na tela. Caso o usuário queira editar novamente, será necessário clicar novamente na ferramenta de edição e depois clicar no elemento