### PR TITLE
fix: contorno de seleção não atualiza após agrupar/desagrupar (Ctrl+G / Ctrl+Shift+G)

### DIFF
--- a/js/core/GroupManager.js
+++ b/js/core/GroupManager.js
@@ -1,4 +1,4 @@
-import { estado, registrarAcaoHistorico } from './StateManager.js';
+import { estado, registrarAcaoHistorico, definirElementosSelecionados } from './StateManager.js';
 import { criarElementoSVG } from '../utils/svgHelpers.js';
 
 /**
@@ -38,13 +38,9 @@ export function agruparElementos() {
         grupo.appendChild(el);
     });
 
-    // Atualiza o estado da seleção: agora o grupo inteiro é o selecionado
-    estado.elementosSelecionados = [grupo];
-
-    // Refaz o desenho da borda azul ao redor do novo grupo
-    if (estado.gerenciadorSelecao) {
-        estado.gerenciadorSelecao.desenhar(estado.elementosSelecionados);
-    }
+    // Atualiza o estado da seleção e redesenha a borda azul:
+    // agora o grupo inteiro é o selecionado
+    definirElementosSelecionados([grupo]);
 
     // Registra a criação do grupo para o Ctrl+Z funcionar
     registrarAcaoHistorico();
@@ -145,11 +141,7 @@ export function desagruparElementos() {
 
     // Se pelo menos um grupo foi desfeito, atualiza o estado e o histórico
     if (ocorreuDesagrupamento) {
-        estado.elementosSelecionados = novaSelecao;
-
-        if (estado.gerenciadorSelecao) {
-            estado.gerenciadorSelecao.desenhar(estado.elementosSelecionados);
-        }
+        definirElementosSelecionados(novaSelecao);
 
         registrarAcaoHistorico();
     }


### PR DESCRIPTION
Closes #207

### Problema
Ao agrupar (`Ctrl+G`) ou desagrupar (`Ctrl+Shift+G`), o retângulo tracejado azul continuava mostrando a geometria antiga da seleção — só corrigia ao clicar de novo. Causa: o `GroupManager.js` tentava redesenhar o contorno via `estado.gerenciadorSelecao`, propriedade que **não existe** no `estado` (o gerenciador visual é uma variável privada do módulo `StateManager.js`). Como `undefined` é falsy, o `if` falhava em silêncio e o redesenho nunca acontecia.

### Solução
Substitui a mutação direta de `estado.elementosSelecionados` + o bloco `if` morto por **uma** chamada à função pública `definirElementosSelecionados(...)`, que já atualiza o estado e redesenha o contorno num só lugar. O diff remove mais linhas do que adiciona (+10/−13) e elimina a duplicação.

### Como testar
1. Desenhar 2+ formas e selecioná-las com Shift+clique
2. `Ctrl+G` → o tracejado azul envolve o grupo **imediatamente**
3. `Ctrl+Shift+G` → o contorno volta a envolver os elementos soltos
4. `Ctrl+Z`/`Ctrl+Y` seguem funcionando (agrupar/desagrupar continuam entrando no histórico)
