### PR TITLE
feat: adiciona ferramenta Estrela (#165)

### DIFF
--- a/index.html
+++ b/index.html
@@ -118,6 +118,9 @@
                 <button id="btn-criar-losango" class="btn-ferramenta" data-ferramenta="losango" data-nome="Losango" data-tooltip="Losango (G)">
                     &#9671;
                 </button>
+                <button id="btn-criar-estrela" class="btn-ferramenta" data-ferramenta="estrela" data-nome="Estrela" data-tooltip="Estrela">
+                    &#9734;
+                </button>
                 <button id="btn-criar-elipse" class="btn-ferramenta" data-ferramenta="elipse" data-nome="Elipse" data-tooltip="Elipse (E)">
                     &#9711;
                 </button>

--- a/js/main.js
+++ b/js/main.js
@@ -45,6 +45,7 @@ import { obterCoordenadaSVG } from './utils/svgHelpers.js';
 import { HistoryManager } from './core/HistoryManager.js';
 import { Regua } from './core/Regua.js';
 import { LosangoTool } from './tools/LosangoTool.js';
+import { EstrelaTool } from './tools/EstrelaTool.js';
 import { agruparElementos, desagruparElementos } from './core/GroupManager.js';
 
 const svgCanvas = document.getElementById('canvas');
@@ -198,6 +199,7 @@ const instanciasFerramentas = {
   borracha: new BorrachaTool(svgCanvas),
   lapis: new Lapis(svgCanvas),
   losango: new LosangoTool(svgCanvas),
+  estrela: new EstrelaTool(svgCanvas),
   pincel: new PincelTool(svgCanvas),
 };
 

--- a/js/tools/EstrelaTool.js
+++ b/js/tools/EstrelaTool.js
@@ -1,0 +1,101 @@
+import { ToolBase } from './ToolBase.js';
+import { criarElementoSVG, obterCoordenadaSVG } from '../utils/svgHelpers.js';
+import { estado } from '../core/StateManager.js';
+import { registrarAcaoHistorico } from '../core/StateManager.js';
+
+/**
+ * Ferramenta/Tool responsável por desenhar estrelas no canvas SVG.
+ * O clique define o centro e o arrasto define o raio externo.
+ * Herda de ToolBase.
+ */
+export class EstrelaTool extends ToolBase {
+  constructor(svgCanvas) {
+    super();
+    this.svgCanvas = svgCanvas;
+    this.isDrawing = false;
+    this.centroX = 0;
+    this.centroY = 0;
+    this.raioAtual = 0;
+    this.estrelaElement = null;
+  }
+
+  onMouseDown(evento) {
+    this.isDrawing = true;
+
+    // Obtém coordenadas exatas em relação ao SVG
+    const pt = obterCoordenadaSVG(evento, this.svgCanvas);
+    this.centroX = pt.x;
+    this.centroY = pt.y;
+    this.raioAtual = 0;
+
+    // Cria o elemento SVG <polygon> dinamicamente
+    this.estrelaElement = criarElementoSVG('polygon', {
+      points: '',
+      'data-shape': 'estrela',
+      fill: estado.corPreenchimento,
+      stroke: estado.corBorda,
+      'stroke-width': 2
+    });
+
+    this.svgCanvas.appendChild(this.estrelaElement);
+  }
+
+  onMouseMove(evento) {
+    if (!this.isDrawing || !this.estrelaElement) return;
+
+    const pt = obterCoordenadaSVG(evento, this.svgCanvas);
+    this.raioAtual = Math.hypot(pt.x - this.centroX, pt.y - this.centroY);
+
+    this.estrelaElement.setAttribute(
+      'points',
+      this._gerarPontos(this.centroX, this.centroY, this.raioAtual)
+    );
+  }
+
+  onMouseUp(evento) {
+    if (!this.isDrawing) return;
+
+    // Um clique sem arrasto criaria uma estrela de raio ~0, invisível e
+    // impossível de selecionar depois — descarta em vez de registrar
+    if (this.estrelaElement && this.raioAtual < 2) {
+      this.estrelaElement.remove();
+      this.isDrawing = false;
+      this.estrelaElement = null;
+      return;
+    }
+
+    // Finaliza a operação de desenho
+    this.isDrawing = false;
+    this.estrelaElement = null;
+
+    // Integração com o History Manager
+    registrarAcaoHistorico();
+  }
+
+  onDesativar() {
+    // Se a ferramenta for desativada no meio do desenho, cancela
+    if (this.isDrawing && this.estrelaElement) {
+      this.estrelaElement.remove();
+      this.isDrawing = false;
+      this.estrelaElement = null;
+    }
+  }
+
+  /**
+   * Gera os 2N vértices da estrela alternando entre o raio externo e o
+   * interno, em ângulos igualmente espaçados. O -PI/2 faz a primeira
+   * ponta apontar para cima.
+   */
+  _gerarPontos(cx, cy, raioExterno, numPontas = 5) {
+    const raioInterno = raioExterno * 0.4;
+    const pontos = [];
+
+    for (let i = 0; i < 2 * numPontas; i++) {
+      const raio = (i % 2 === 0) ? raioExterno : raioInterno;
+      const angulo = -Math.PI / 2 + (i * Math.PI) / numPontas;
+      pontos.push(`${cx + raio * Math.cos(angulo)},${cy + raio * Math.sin(angulo)}`);
+    }
+
+    return pontos.join(' ');
+  }
+}


### PR DESCRIPTION
Closes #165

### Resumo
- Nova `js/tools/EstrelaTool.js`: o clique define o centro e o arrasto define o raio externo (a ponta acompanha o cursor). Gera um `<polygon>` de 2N vértices alternando raio externo/interno (proporção clássica de 0,4), com a primeira ponta apontando para cima e `data-shape="estrela"`.
- Registro da ferramenta em `main.js` e botão ☆ na barra lateral (`index.html`), no padrão dos botões vizinhos.

### Integrações
- **Histórico**: a criação entra no `registrarAcaoHistorico()` — `Ctrl+Z`/`Ctrl+Y` funcionam.
- **Seleção**: a estrela já nasce selecionável e móvel pela ferramenta de seleção (`polygon` está nas tags permitidas).
- Clique sem arrasto é descartado (não cria polígono invisível e inselecionável); trocar de ferramenta no meio do arrasto cancela o desenho (`onDesativar`).

### Decisões e coordenação
- **Sem atalho de teclado por enquanto**: o mapa de teclas está sendo refeito no PR #177 — adiciono o atalho depois que ele mesclar.
- Conflito trivial esperado com os PRs #169 (Polígono Regular) e #208 (Espiral) nas mesmas linhas de registro em `main.js`/`index.html` — são issues distintas e aprovadas separadamente; me comprometo a rebasear este PR se os outros mesclarem primeiro.
- @gabriel-lemos05 @DavidGBUF: vi que a issue estava Aprovada e sem responsável desde 30/06 e que vocês estão com os PRs #181/#199 em andamento — se algum de vocês preferir assumi-la, sem problema, fecho este PR.
