### PR TITLE
feat: ativa a edição de vértices do losango (LosangoShape)

### DIFF
--- a/js/shape/LosangoShape.js
+++ b/js/shape/LosangoShape.js
@@ -1,11 +1,11 @@
-import { ShapeBase } from "./ShapeBase";
+import { ShapeBase } from "./ShapeBase.js";
 
 export class LosangoShape extends ShapeBase {
     constructor(svgCanvas) {
         super(svgCanvas);
     }
 
-    renderizarTodosOsHandles(targetElement) {
+    renderizarTodosHandles(targetElement) {
         const x = parseFloat(targetElement.getAttribute('x'));
         const y = parseFloat(targetElement.getAttribute('y'));
         const w = parseFloat(targetElement.getAttribute('width'));
@@ -38,27 +38,27 @@ export class LosangoShape extends ShapeBase {
                 targetElement.setAttribute('width', Math.max(0, (x + w) - coords.x));
                 break;
             case 'right':
-                targetElement.setAttribute('width', coords.x - x);
+                targetElement.setAttribute('width', Math.max(0, coords.x - x));
                 break;
             case 'bottom':
-                targetElement.setAttribute('height', coords.y - y);
+                targetElement.setAttribute('height', Math.max(0, coords.y - y));
                 break;
-
-            // Redefinição dos pontos do Losango
-            const nx = parseFloat(targetElement.getAttribute('x'));
-            const ny = parseFloat(targetElement.getAttribute('y'));
-            const nw = parseFloat(targetElement.getAttribute('width'));
-            const nh = parseFloat(targetElement.getAttribute('height'));
-
-            const centroX = nx + nw / 2;
-            const centroY = ny + nh / 2;
-
-            const novosPontos = `${centroX},${ny} ${nx + nw},${centroY} ${centroX},${ny + nh} ${nx},${centroY}`;
-            targetElement.setAttribute('points', novosPontos);
-
-            // Sincroniza os nodes (vértices)
-            this.sincronizarTodosOsHandles(targetElement);
         }
+
+        // Redefinição dos pontos do Losango
+        const nx = parseFloat(targetElement.getAttribute('x'));
+        const ny = parseFloat(targetElement.getAttribute('y'));
+        const nw = parseFloat(targetElement.getAttribute('width'));
+        const nh = parseFloat(targetElement.getAttribute('height'));
+
+        const centroX = nx + nw / 2;
+        const centroY = ny + nh / 2;
+
+        const novosPontos = `${centroX},${ny} ${nx + nw},${centroY} ${centroX},${ny + nh} ${nx},${centroY}`;
+        targetElement.setAttribute('points', novosPontos);
+
+        // Sincroniza os nodes (vértices)
+        this.sincronizarTodosOsHandles(targetElement);
     }
 
     sincronizarTodosOsHandles(targetElement){

--- a/js/tools/NodeEditTool.js
+++ b/js/tools/NodeEditTool.js
@@ -3,6 +3,7 @@ import { obterCoordenadaSVG } from '../utils/svgHelpers.js';
 import { RetanguloShape } from '../shape/RetanguloShape.js';
 import { ElipseShape } from '../shape/ElipseShape.js';
 import { LinhaCurvadaShape } from '../shape/LinhaCurvadaShape.js';
+import { LosangoShape } from '../shape/LosangoShape.js';
 import { registrarAcaoHistorico } from '../core/StateManager.js';
 
 /**
@@ -23,6 +24,7 @@ export class NodeEditTool extends ToolBase {
             'ellipse': new ElipseShape(svgCanvas),
             'image': new RetanguloShape(svgCanvas), // Image possui as mesmas propriedades de retangulos
             'linhaCurvada': new LinhaCurvadaShape(svgCanvas),
+            'losango': new LosangoShape(svgCanvas),
         }
     }
 
@@ -34,6 +36,12 @@ export class NodeEditTool extends ToolBase {
         if (tag === 'path') {
             return elemento.dataset && elemento.dataset.tipoLinha === 'linhaCurvada'
                 ? 'linhaCurvada'
+                : null;
+        }
+
+        if (tag === 'polygon') {
+            return elemento.dataset && elemento.dataset.shape === 'losango'
+                ? 'losango'
                 : null;
         }
 


### PR DESCRIPTION
Closes #203

### Contexto
A `LosangoShape` existia em `js/shape/` desde o commit c021a30, mas nunca funcionou: não estava registrada no `NodeEditTool` e tinha defeitos internos que impediriam a edição mesmo se registrada.

### O que este PR corrige
1. **Registro + despacho**: `losango` entra no `allowedShapes`, e `obterTipoEditavel()` ganha a resolução de `polygon` por `data-shape="losango"` — no mesmo padrão que o PR #202 estabeleceu para `path`/`data-tipo-linha`. Polígonos comuns (sem `data-shape`) seguem intocados.
2. **Código morto**: o recálculo dos `points` em `atualizarForma()` estava *depois* do último `break`, dentro do `switch` — nunca executava (arrastar um vértice mudava `x/y/width/height` sem mover o desenho). Movido para fora do `switch`, na estrutura da `RetanguloShape`.
3. **Contrato da base**: `renderizarTodosOsHandles` → `renderizarTodosHandles` (nome que o `NodeEditTool` chama; antes cairia na implementação vazia da `ShapeBase`).
4. **Import**: `./ShapeBase` → `./ShapeBase.js` (sem a extensão, o módulo nem carrega em ES modules puros).
5. **Clamps**: `Math.max(0, ...)` também nos vértices `right`/`bottom`, evitando dimensões negativas.

A edição é **paramétrica**: arrastar um vértice preserva a simetria das diagonais e mantém `points` e `x/y/width/height` sincronizados — o que a edição livre de polígonos genéricos não daria ao losango.

### Como testar
1. Desenhar um losango (◇) → ferramenta **V** → clicar nele: 4 alças aparecem nos vértices
2. Arrastar a alça direita: o losango alarga acompanhando o cursor, e as alças ressincronizam
3. `Ctrl+Z` desfaz a edição
4. Retângulo/elipse/linha curvada seguem editáveis como antes; polígonos comuns não ganham alças

### Escopo e coordenação
- **Losango movido** pela seleção (`transform="translate"`) fica fora desta v1 de propósito: o @cyberchristian92 diagnosticou esse caso no PR #175 e vai implementar a compensação de offset na infraestrutura de shapes — quando entrar, o losango herda o tratamento.
- Conflito trivial esperado com o PR #175 no `NodeEditTool.js` (ambos registram shapes) — me comprometo a rebasear se ele mesclar primeiro, @carloscardoso05.
