### PR TITLE
feat: adiciona espelhamento horizontal e vertical de objetos v2

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,6 +67,15 @@
                 <button id="btn-step-forward" title="Avançar" class="btn-layer">⏩</button>
                 <button id="btn-bring-to-front" title="Trazer para a Frente" class="btn-layer">⏭</button>
             </div>
+            
+            <!-- Botões de Espelhamento -->
+            <button id="btn-flip-horizontal" class="btn-layer" title="Espelhar Horizontal">
+                ↔
+            </button>
+
+            <button id="btn-flip-vertical" class="btn-layer" title="Espelhar Vertical">
+                ↕
+            </button>
 
             <!-- Controle de Visualização (Réguas de medida) -->
             <div class="view-controls">

--- a/js/main.js
+++ b/js/main.js
@@ -18,7 +18,8 @@ import {
   definirGerenciadorHistorico,
   desfazerAcao,
   refazerAcao,
-  registrarAcaoHistorico
+  registrarAcaoHistorico,
+  atualizarPosicaoSelecaoVisual
 } from './core/StateManager.js';
 import { ColorPickerTool } from './tools/ColorPickerTool.js';
 import { Lapis } from './tools/LapisTool.js';
@@ -46,6 +47,7 @@ import { HistoryManager } from './core/HistoryManager.js';
 import { Regua } from './core/Regua.js';
 import { LosangoTool } from './tools/LosangoTool.js';
 import { agruparElementos, desagruparElementos } from './core/GroupManager.js';
+import { espelharHorizontal, espelharVertical } from "./utils/flipHelpers.js";
 
 const svgCanvas = document.getElementById('canvas');
 
@@ -373,6 +375,32 @@ btnSendToBack.addEventListener('click', () => moverCamada('fundo'));
 btnStepBackward.addEventListener('click', () => moverCamada('recuar'));
 btnStepForward.addEventListener('click', () => moverCamada('avancar'));
 btnBringToFront.addEventListener('click', () => moverCamada('frente'));
+
+// --- Configurar Espelhamento ---
+const btnFlipHorizontal = document.getElementById('btn-flip-horizontal');
+const btnFlipVertical = document.getElementById('btn-flip-vertical');
+
+btnFlipHorizontal.addEventListener("click", () => {
+
+    estado.elementosSelecionados.forEach(el => {
+        espelharHorizontal(el);
+    });
+
+    atualizarPosicaoSelecaoVisual();
+    registrarAcaoHistorico();
+
+});
+
+btnFlipVertical.addEventListener("click", () => {
+
+    estado.elementosSelecionados.forEach(el => {
+        espelharVertical(el);
+    });
+
+    atualizarPosicaoSelecaoVisual();
+    registrarAcaoHistorico();
+
+});
 
 // Atalhos de Teclado (Tool Selection)
 window.addEventListener("keydown", (e) => {

--- a/js/tools/SelecaoTool.js
+++ b/js/tools/SelecaoTool.js
@@ -8,6 +8,7 @@ import {
   atualizarPosicaoSelecaoVisual,
   registrarAcaoHistorico
 } from '../core/StateManager.js';
+import { atualizarTransformacao } from '../utils/flipHelpers.js';
 
 /**
  * Ferramenta de Seleção
@@ -124,6 +125,7 @@ export class SelecaoTool extends ToolBase {
       if (tag === 'rect' || tag === 'text' || tag === 'image') {
         el.setAttribute('x', String(novoX));
         el.setAttribute('y', String(novoY));
+        atualizarTransformacao(el);
       } else if (tag === 'polygon' && el.dataset.shape === 'losango') {
     // Código atual do losango
     el.setAttribute('x', String(novoX));
@@ -139,11 +141,15 @@ export class SelecaoTool extends ToolBase {
         `${centroX},${novoY} ${novoX + w},${centroY} ${centroX},${novoY + h} ${novoX},${centroY}`;
 
     el.setAttribute('points', novosPontos);
+
+    atualizarTransformacao(el);
       }else if (tag === 'polygon' && el.dataset.shape === 'poligono') {
         this._definirTranslacao(el, novoX, novoY);
+        atualizarTransformacao(el);
       }else if (tag === 'circle' || tag === 'ellipse') {
         el.setAttribute('cx', String(novoX));
         el.setAttribute('cy', String(novoY));
+        atualizarTransformacao(el);
       } else if (tag === 'line') {
           // Exemplo simplificado para linha (move mantendo comprimento)
           const dx = novoX - parseFloat(el.getAttribute('x1') || 0);
@@ -155,6 +161,7 @@ export class SelecaoTool extends ToolBase {
       } else if (tag === 'path' || tag === 'g' || tag == 'polygon') {
         // Aplica a translação nativa em vez de escrever string template
         this._definirTranslacao(el, novoX, novoY);
+        atualizarTransformacao(el);
       }
     });
 

--- a/js/utils/flipHelpers.js
+++ b/js/utils/flipHelpers.js
@@ -1,0 +1,116 @@
+function obterCentro(elemento) {
+
+    const box = elemento.getBBox();
+
+    return {
+        cx: box.x + box.width / 2,
+        cy: box.y + box.height / 2
+    };
+
+}
+
+function numero(elemento, atributo) {
+    return parseFloat(elemento.getAttribute(atributo) || 0);
+}
+
+export function atualizarTransformacao(elemento) {
+
+    const { cx, cy } = obterCentro(elemento);
+
+    const flipH = elemento.dataset.flipH === "true";
+    const flipV = elemento.dataset.flipV === "true";
+
+    const scaleX = flipH ? -1 : 1;
+    const scaleY = flipV ? -1 : 1;
+
+    const tx = parseFloat(elemento.dataset.translateX || 0);
+    const ty = parseFloat(elemento.dataset.translateY || 0);
+
+    elemento.setAttribute(
+        "transform",
+        `translate(${tx}, ${ty})
+         translate(${cx}, ${cy})
+         scale(${scaleX}, ${scaleY})
+         translate(${-cx}, ${-cy})`
+    );
+}
+
+function alternarEspelhamentoHorizontal(elemento) {
+
+    elemento.dataset.flipH =
+        elemento.dataset.flipH === "true" ? "false" : "true";
+
+    atualizarTransformacao(elemento);
+}
+
+function alternarEspelhamentoVertical(elemento) {
+
+    elemento.dataset.flipV =
+        elemento.dataset.flipV === "true" ? "false" : "true";
+
+    atualizarTransformacao(elemento);
+}
+
+export function espelharHorizontal(elemento) {
+
+    const tag = elemento.tagName.toLowerCase();
+
+    // Linha
+    if (tag === "line") {
+
+        const { cx } = obterCentro(elemento);
+
+        const x1 = numero(elemento, "x1");
+        const x2 = numero(elemento, "x2");
+
+        elemento.setAttribute("x1", 2 * cx - x1);
+        elemento.setAttribute("x2", 2 * cx - x2);
+
+        return;
+    }
+
+    // Imagem, Texto, Retangulo, Desenho a Lapis e Circulo/Elipse
+    if (
+        tag === "image" ||
+        tag === "text" ||
+        tag === "rect" ||
+        tag === "path" ||
+        tag === "circle" ||
+        tag === "ellipse"
+    ) {
+        alternarEspelhamentoHorizontal(elemento);
+        return;
+    }
+}
+
+export function espelharVertical(elemento) {
+
+    const tag = elemento.tagName.toLowerCase();
+
+    // Linha
+    if (tag === "line") {
+
+        const { cy } = obterCentro(elemento);
+
+        const y1 = numero(elemento, "y1");
+        const y2 = numero(elemento, "y2");
+
+        elemento.setAttribute("y1", 2 * cy - y1);
+        elemento.setAttribute("y2", 2 * cy - y2);
+
+        return;
+    }
+
+    // Imagem, Texto, Retangulo, Desenho a Lapis e Circulo/Elipse
+    if (
+        tag === "image" ||
+        tag === "text" ||
+        tag === "rect" ||
+        tag === "path" ||
+        tag === "circle" ||
+        tag === "ellipse"
+    ) {
+        alternarEspelhamentoVertical(elemento);
+        return;
+    }
+}


### PR DESCRIPTION
## O que foi feito

Implementa o espelhamento horizontal e vertical dos elementos selecionados do editor.

### Suportados

- Retângulo
- Elipse
- Linha
- Texto
- Imagem
- Lápis

### Melhorias

- Refatoração da lógica de transformações para `flipHelpers.js`;
- Preservação do espelhamento durante movimentação;
- Espelhamento reversível (pressionar novamente desfaz);
- Compatibilidade com a nova arquitetura da ferramenta de seleção.

### Observações

Polígono/Polilinha e Pincel Dinâmico não receberam suporte porque atualmente esses elementos já apresentam limitações na ferramenta de seleção (movimentação e edição), independentes desta implementação.

@gustavoresque 

Closes #164