### PR TITLE
213 medidas da régua sobrepõem os pop ups dos elementos

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -423,7 +423,7 @@ body {
   background-color: var(--cor-fundo-barra);
   border-right: 1px solid var(--cor-borda-ui);
   border-bottom: 1px solid var(--cor-borda-ui);
-  z-index: 7;
+  z-index: 2;
 }
 
 .regua-marcador {

--- a/css/style.css
+++ b/css/style.css
@@ -471,6 +471,7 @@ body {
   border-radius: var(--raio-borda);
   flex-direction: column;
   gap: 4px;
+  z-index: 20;
 }
 
 #zoom-options.hidden,

--- a/css/style.css
+++ b/css/style.css
@@ -395,7 +395,7 @@ body {
   color: var(--cor-texto-secundario);
   font-size: 10px;
   font-family: sans-serif;
-  z-index: 6;
+  z-index: 1;
   pointer-events: none;
   overflow: hidden;
 }


### PR DESCRIPTION
# Problema

Atualmente, as medidas exibidas pela régua são renderizadas acima dos pop-ups de ferramentas e elementos, como elipse, círculo, seleção de linhas e outros.

# Comportamento esperado

Os pop-ups devem ser exibidos acima das medidas da régua, garantindo que suas opções permaneçam totalmente visíveis e acessíveis durante a interação.

# Impacto

* As medidas da régua sobrepõem parte dos pop-ups.
* A interface fica visualmente inconsistente.
* Algumas opções podem ficar parcialmente ocultas, prejudicando a usabilidade.



<img width="677" height="732" alt="{44A37ADB-8E8B-4844-B773-C53C9122C4E8}" src="https://github.com/user-attachments/assets/88fbc842-8785-452c-aed1-d8e737d282c8" />
