### PR TITLE
76/selecao de linha

### DIFF
--- a/js/tools/ElipseTool.js
+++ b/js/tools/ElipseTool.js
@@ -8,6 +8,12 @@ import { definirElementosSelecionados } from '../core/StateManager.js';
  * ElipseTool
  * 
  * Ferramenta responsável por desenhar elipses no canvas SVG.
+ *
+ * Modificadores de teclado durante o desenho:
+ * - Ctrl  -> Simetria: força um círculo perfeito (rx === ry).
+ * - Shift -> Centralidade: o ponto inicial do clique vira o centro da
+ *            elipse, em vez de um dos cantos do retângulo delimitador.
+ * (Os dois podem ser usados juntos: círculo desenhado a partir do centro.)
  */
 export class ElipseTool extends ToolBase {
   constructor(svgCanvas) {
@@ -17,6 +23,23 @@ export class ElipseTool extends ToolBase {
     this.startX = 0;
     this.startY = 0;
     this.elipseElement = null;
+
+    // Último ponto do mouse conhecido, usado para recalcular a geometria
+    // imediatamente quando o usuário pressiona/solta Ctrl ou Shift.
+    this.ultimoPonto = null;
+
+    // Estado dos modificadores de teclado
+    this.ctrlPressionado = false;
+    this.shiftPressionado = false;
+
+    // Bindings para poder adicionar/remover os listeners corretamente
+    this.onKeyDownBound = this.onKeyDown.bind(this);
+    this.onKeyUpBound = this.onKeyUp.bind(this);
+  }
+
+  onAtivar() {
+    window.addEventListener('keydown', this.onKeyDownBound);
+    window.addEventListener('keyup', this.onKeyUpBound);
   }
 
   onMouseDown(evento) {
@@ -25,6 +48,7 @@ export class ElipseTool extends ToolBase {
     const pt = obterCoordenadaSVG(evento, this.svgCanvas);
     this.startX = pt.x;
     this.startY = pt.y;
+    this.ultimoPonto = pt;
 
     // Cria o elemento <ellipse>. 
     // Inicialmente com raios zero no ponto de clique.
@@ -44,16 +68,80 @@ export class ElipseTool extends ToolBase {
   onMouseMove(evento) {
     if (!this.isDrawing || !this.elipseElement) return;
 
-    const pt = obterCoordenadaSVG(evento, this.svgCanvas);
+    this.ultimoPonto = obterCoordenadaSVG(evento, this.svgCanvas);
+    this._atualizarElipse();
+  }
 
-    // Cálculos matemáticos para a elipse
-    // O raio é metade da distância absoluta entre o início e o cursor
-    const rx = Math.abs(pt.x - this.startX) / 2;
-    const ry = Math.abs(pt.y - this.startY) / 2;
+  onMouseUp(evento) {
+    this.isDrawing = false;
+    this.elipseElement = null;
+    this.ultimoPonto = null;
 
-    // O centro (cx, cy) deve ser o ponto médio entre o clique inicial e o cursor
-    const cx = (this.startX + pt.x) / 2;
-    const cy = (this.startY + pt.y) / 2;
+    // Integração com o History Manager
+    registrarAcaoHistorico();
+  }
+
+  onKeyDown(evento) {
+    let alterou = false;
+
+    if (evento.key === 'Control' && !this.ctrlPressionado) {
+      this.ctrlPressionado = true;
+      alterou = true;
+    }
+
+    if (evento.key === 'Shift' && !this.shiftPressionado) {
+      this.shiftPressionado = true;
+      alterou = true;
+    }
+
+    // Atualiza a elipse em tempo real, sem precisar mover o mouse
+    if (alterou && this.isDrawing) {
+      this._atualizarElipse();
+    }
+  }
+
+  onKeyUp(evento) {
+    let alterou = false;
+
+    if (evento.key === 'Control') {
+      this.ctrlPressionado = false;
+      alterou = true;
+    }
+
+    if (evento.key === 'Shift') {
+      this.shiftPressionado = false;
+      alterou = true;
+    }
+
+    if (alterou && this.isDrawing) {
+      this._atualizarElipse();
+    }
+  }
+
+  onDesativar() {
+    window.removeEventListener('keydown', this.onKeyDownBound);
+    window.removeEventListener('keyup', this.onKeyUpBound);
+
+    this.ctrlPressionado = false;
+    this.shiftPressionado = false;
+
+    if (this.isDrawing && this.elipseElement) {
+      this.elipseElement.remove();
+      this.isDrawing = false;
+      this.elipseElement = null;
+      this.ultimoPonto = null;
+    }
+  }
+
+  /**
+   * Recalcula e aplica cx, cy, rx e ry no elemento de elipse em desenho,
+   * de acordo com o último ponto do mouse e os modificadores pressionados.
+   * @private
+   */
+  _atualizarElipse() {
+    if (!this.elipseElement || !this.ultimoPonto) return;
+
+    const { cx, cy, rx, ry } = this._calcularGeometria(this.ultimoPonto);
 
     this.elipseElement.setAttribute('cx', cx);
     this.elipseElement.setAttribute('cy', cy);
@@ -61,19 +149,39 @@ export class ElipseTool extends ToolBase {
     this.elipseElement.setAttribute('ry', ry);
   }
 
-  onMouseUp(evento) {
-    this.isDrawing = false;
-    this.elipseElement = null;
+  /**
+   * Calcula o centro (cx, cy) e os raios (rx, ry) da elipse a partir do
+   * ponto inicial do clique, do ponto atual do mouse e dos modificadores
+   * de teclado (Ctrl = simetria/círculo, Shift = desenho a partir do centro).
+   * @private
+   */
+  _calcularGeometria(pt) {
+    const dx = pt.x - this.startX;
+    const dy = pt.y - this.startY;
 
-    // Integração com o History Manager
-    registrarAcaoHistorico();
-  }
+    let cx, cy, rx, ry;
 
-  onDesativar() {
-    if (this.isDrawing && this.elipseElement) {
-      this.elipseElement.remove();
-      this.isDrawing = false;
-      this.elipseElement = null;
+    if (this.shiftPressionado) {
+      // Centralidade: o clique inicial é o centro da elipse
+      cx = this.startX;
+      cy = this.startY;
+      rx = Math.abs(dx);
+      ry = Math.abs(dy);
+    } else {
+      // Comportamento padrão: o clique inicial é um canto do retângulo delimitador
+      cx = (this.startX + pt.x) / 2;
+      cy = (this.startY + pt.y) / 2;
+      rx = Math.abs(dx) / 2;
+      ry = Math.abs(dy) / 2;
     }
+
+    if (this.ctrlPressionado) {
+      // Simetria: força um círculo perfeito, usando o maior raio calculado
+      const raio = Math.max(rx, ry);
+      rx = raio;
+      ry = raio;
+    }
+
+    return { cx, cy, rx, ry };
   }
 }

--- a/js/tools/LinhaTool.js
+++ b/js/tools/LinhaTool.js
@@ -29,8 +29,12 @@ export class LinhaTool extends ToolBase {
       x2: pt.x, y2: pt.y,
       stroke: estado.corBorda,
       'stroke-width': 2,
+
+    'pointer-events': 'stroke',
+    'vector-effect': 'non-scaling-stroke',
       ...this.obterAtributosEstiloLinha()
     });
+    this.lineElement.setAttribute("stroke-linecap", "round");
     this.svgCanvas.appendChild(this.lineElement);
   }
 

--- a/js/tools/SelecaoTool.js
+++ b/js/tools/SelecaoTool.js
@@ -75,7 +75,13 @@ export class SelecaoTool extends ToolBase {
     const tag = target.tagName ? target.tagName.toLowerCase() : '';
 
     // Verifica se o clique foi em um elemento válido dentro do canvas
-    const elementoAlvo = this._buscarElementoValido(target, allowedTags);
+    let elementoAlvo = this._buscarElementoValido(target, allowedTags);
+
+    // Fallback: se nada foi encontrado diretamente, tenta encontrar uma
+    // linha próxima ao clique (área de seleção maior que a espessura visual)
+    if (!elementoAlvo) {
+      elementoAlvo = this._buscarLinhaProxima(pt);
+    }
 
     if (elementoAlvo) {
       this._aplicarSelecaoComModificador(elementoAlvo, isShift, isCtrl);
@@ -300,18 +306,8 @@ export class SelecaoTool extends ToolBase {
   _buscarElementoValido(target, allowedTags) {
     if (target === this.svgCanvas || target.id === 'canvas') return null;
 
-    // Em vez de usar closest(), vamos subir na árvore e salvar o grupo mais ALTO (externo)
-    let grupoMaisExterno = null;
-    let atualBuscaGrupo = target;
-
-    while (atualBuscaGrupo && atualBuscaGrupo !== this.svgCanvas) {
-      if (atualBuscaGrupo.tagName && atualBuscaGrupo.tagName.toLowerCase() === 'g') {
-        grupoMaisExterno = atualBuscaGrupo; // Atualiza a variável toda vez que achar um <g>
-      }
-      atualBuscaGrupo = atualBuscaGrupo.parentNode;
-    }
-
     // Se o elemento pertence a um ou mais grupos, seleciona o "Grupo Mestre" (o mais externo)
+    const grupoMaisExterno = this._encontrarGrupoExterno(target);
     if (grupoMaisExterno) {
       return grupoMaisExterno;
     }
@@ -327,6 +323,104 @@ export class SelecaoTool extends ToolBase {
     }
 
     return null;
+  }
+
+  /**
+   * Sobe na árvore a partir de um elemento e retorna o <g> mais externo
+   * (o "grupo mestre") ao qual ele pertence, se houver algum.
+   * @private
+   */
+  _encontrarGrupoExterno(elemento) {
+    let grupoMaisExterno = null;
+    let atual = elemento;
+
+    while (atual && atual !== this.svgCanvas) {
+      if (atual.tagName && atual.tagName.toLowerCase() === 'g') {
+        grupoMaisExterno = atual; // Atualiza a variável toda vez que achar um <g>
+      }
+      atual = atual.parentNode;
+    }
+
+    return grupoMaisExterno;
+  }
+
+  /**
+   * Fallback de seleção para linhas: como o hit-test nativo do SVG considera
+   * apenas a espessura real do traço (stroke-width), linhas finas são muito
+   * difíceis de clicar. Este método calcula a distância do ponto clicado até
+   * cada segmento de linha do canvas e, se estiver dentro de uma tolerância
+   * (a própria espessura da linha + uma margem extra em pixels de tela,
+   * convertida para o espaço do SVG considerando o zoom atual), considera
+   * a linha como alvo válido — sem alterar a espessura/estilo renderizado.
+   * @private
+   */
+  _buscarLinhaProxima(pt) {
+    const TOLERANCIA_EXTRA_PX = 6;
+    const escala = this._obterEscalaSVG();
+    const toleranciaExtra = TOLERANCIA_EXTRA_PX * escala;
+
+    let linhaMaisProxima = null;
+    let menorDistancia = Infinity;
+
+    const linhas = this.svgCanvas.querySelectorAll('line');
+
+    linhas.forEach((linha) => {
+      const x1 = parseFloat(linha.getAttribute('x1')) || 0;
+      const y1 = parseFloat(linha.getAttribute('y1')) || 0;
+      const x2 = parseFloat(linha.getAttribute('x2')) || 0;
+      const y2 = parseFloat(linha.getAttribute('y2')) || 0;
+
+      const distancia = this._distanciaPontoSegmento(pt.x, pt.y, x1, y1, x2, y2);
+
+      const espessura = parseFloat(linha.getAttribute('stroke-width')) || 1;
+      const raioClicavel = espessura / 2 + toleranciaExtra;
+
+      if (distancia <= raioClicavel && distancia < menorDistancia) {
+        menorDistancia = distancia;
+        linhaMaisProxima = linha;
+      }
+    });
+
+    if (!linhaMaisProxima) return null;
+
+    // Se a linha encontrada pertence a um grupo, seleciona o grupo mestre
+    const grupoMaisExterno = this._encontrarGrupoExterno(linhaMaisProxima);
+    return grupoMaisExterno || linhaMaisProxima;
+  }
+
+  /**
+   * Calcula a menor distância entre um ponto (px, py) e um segmento de reta
+   * definido por (x1, y1) - (x2, y2).
+   * @private
+   */
+  _distanciaPontoSegmento(px, py, x1, y1, x2, y2) {
+    const dx = x2 - x1;
+    const dy = y2 - y1;
+    const comprimentoQuadrado = dx * dx + dy * dy;
+
+    let t = comprimentoQuadrado === 0
+      ? 0
+      : ((px - x1) * dx + (py - y1) * dy) / comprimentoQuadrado;
+    t = Math.max(0, Math.min(1, t));
+
+    const projX = x1 + t * dx;
+    const projY = y1 + t * dy;
+
+    return Math.hypot(px - projX, py - projY);
+  }
+
+  /**
+   * Retorna o fator de escala atual entre o espaço do SVG (viewBox) e os
+   * pixels de tela, para que a tolerância extra de clique se mantenha
+   * visualmente consistente em qualquer nível de zoom.
+   * @private
+   */
+  _obterEscalaSVG() {
+    const viewBox = this.svgCanvas.viewBox && this.svgCanvas.viewBox.baseVal;
+    if (viewBox && viewBox.width && this.svgCanvas.clientWidth) {
+      return viewBox.width / this.svgCanvas.clientWidth;
+    }
+    return 1;
   }
 
   /**


### PR DESCRIPTION
1. Seleção de linha mais fácil (SelecaoTool.js)
Problema: o hit-test nativo do SVG só reconhece clique exatamente em cima do traço (stroke-width), tornando linhas finas difíceis de selecionar.
Solução: adicionado um fallback que só entra em ação quando o clique não acerta nada diretamente:

_buscarLinhaProxima(pt) percorre todas as <line> do canvas e calcula a distância do clique até cada segmento (_distanciaPontoSegmento).
Considera a linha "clicável" dentro de um raio de espessura/2 + 6px (tolerância extra convertida para o espaço do SVG via _obterEscalaSVG, então funciona igual em qualquer zoom).
Se a linha pertencer a um grupo, ainda respeita a seleção do grupo mestre (_encontrarGrupoExterno, extraído do código original para reaproveitamento).

Escopo: só afeta <line> (ferramenta "Linha"). Não altera espessura/estilo visual, e não mexe em borracha, conta-gotas ou outras formas. Não cobre Linha Curvada/Bézier (são <path>) — pode ser estendido se precisar.
2. Simetria e centralidade na Elipse (ElipseTool.js)
Adicionado:

Ctrl → simetria: força rx === ry (círculo perfeito), usando o maior raio calculado no momento.
Shift → centralidade: o ponto do clique inicial vira o centro da elipse (em vez de canto do retângulo delimitador, comportamento anterior).
Os dois combinados (Ctrl+Shift) desenham um círculo a partir do centro.

Como funciona: seguindo o padrão já usado em LinhaCurvadaTool/BezierTool/PoligonoPolilinhaTool, a ferramenta registra seus próprios listeners de keydown/keyup em onAtivar/onDesativar. O último ponto do mouse fica guardado (ultimoPonto), permitindo recalcular a geometria (_calcularGeometria) instantaneamente ao apertar/soltar as teclas, sem precisar mover o mouse.
Escopo: afeta só o momento do desenho com a ferramenta Elipse. Não mexe em ElipseShape.js (edição de vértices depois de criada).