### PR TITLE
feat: adiciona suporte a Undo/Redo na ferramenta Pincel Dinâmico

### DIFF
--- a/js/tools/PincelTool.js
+++ b/js/tools/PincelTool.js
@@ -1,6 +1,6 @@
 import { ToolBase } from './ToolBase.js';
 import { obterCoordenadaSVG } from '../utils/svgHelpers.js';
-import { estado } from '../core/StateManager.js';
+import { estado, registrarAcaoHistorico } from '../core/StateManager.js';
 
 const SVG_NS = 'http://www.w3.org/2000/svg';
 
@@ -91,5 +91,7 @@ export class PincelTool extends ToolBase {
         this.ultimoTempo    = null;
         this.grupo          = null;
         this.espessuraAtual = this.espessuraMin;
+
+        registrarAcaoHistorico();
     }
 }


### PR DESCRIPTION
Closes #222

## O que muda

O PincelTool passa a registrar cada traço finalizado no HistoryManager, seguindo o que o lápis já faz desde a #153. A mudança importa o registrarAcaoHistorico do StateManager e chama a função no onMouseUp, no encerramento do traço.

## Como testei

Com o servidor local, direto no canvas:

- Desenhei com velocidades variadas e a espessura dinâmica continua respondendo normalmente.
- Ctrl+Z remove o último traço do pincel e Ctrl+Y restaura com todos os segmentos.
- Com dois traços na tela, cada Ctrl+Z desfaz um por vez, e os Redo restauram na ordem inversa.
- As outras ferramentas seguem registrando no histórico como antes.