### PR TITLE
fix: contém a scrollbar do canvas em seu próprio contexto de empilham…

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -406,6 +406,8 @@ body {
   align-items: center;
   justify-content: center;
   padding: 24px;
+  position: relative;
+  z-index: 1;
 }
 
 #canvas {


### PR DESCRIPTION
## Descrição

Closes #225

A trilha da `ScrollbarSVG` (`z-index: 10` inline, anexada ao `canvasContainer`) escapava para o contexto de empilhamento de `#workspace`, porque nem `canvasContainer` (`position: relative` sem `z-index`) nem `#area-desenho` estabeleciam um contexto próprio. Isso fazia o `z-index: 10` da scrollbar competir diretamente com o `z-index: 5` de `#barra-ferramentas`, sobrepondo a sidebar inteira, incluindo o tooltip, que tem `z-index: 1000` mas fica preso dentro do contexto de nível 5 da sidebar, sempre que as duas coincidiam verticalmente.

Isso ficava visível especialmente com zoom do navegador diferente de100% ou janelas com pouca altura, cortando o tooltip do botão "Importar Imagem"

## Solução

Adicionado `position: relative; z-index: 1;` em `#area-desenho`, criando um contexto de empilhamento que contém a scrollbar sem mudar nenhum comportamento de layout, já que `canvasContainer` já definia seu próprio `position: relative` para as camadas internas (`overlayCanvas`, `ScrollbarSVG`).
