### PR TITLE
155 fix tornar fator de zoom consistente e reversível

### DIFF
--- a/js/core/CameraSVG.js
+++ b/js/core/CameraSVG.js
@@ -113,22 +113,40 @@ export class CameraSVG {
   zoomToRect(x, y, width, height) {
     if (!width || !height || width <= 0) return;
 
-    const minW = this.initialViewBox.width / (this.maxZoomLimit / 100);
+    // 1. Pega a proporção física real da tela em pixels
+    const svgEl = this.svgs[0];
+    const screenWidth = svgEl.clientWidth || 800;
+    const screenHeight = svgEl.clientHeight || 600;
+    const aspect = screenWidth / screenHeight;
 
-    // Se o usuário selecionou uma área minúscula que estouraria o limite:
-    if (width < minW) {
-      const correctionScale = minW / width;
-      const newW = minW;
-      const newH = height * correctionScale;
+    let newWidth = width;
+    let newHeight = height;
 
-      // Centraliza o novo viewBox seguro no retângulo original
-      x = x - (newW - width) / 2;
-      y = y - (newH - height) / 2;
-      width = newW;
-      height = newH;
+    // 2. Ajusta o retângulo matemático
+    if (newWidth / newHeight > aspect) {
+      newHeight = newWidth / aspect;
+    } else {
+      newWidth = newHeight * aspect;
     }
 
-    this.viewBox = { x, y, width, height };
+    const minW = this.initialViewBox.width / (this.maxZoomLimit / 100);
+
+    // 3. Se ultrapassar o limite, crava o tamanho mínimo seguro matematicamente
+    if (newWidth < minW) {
+      newWidth = minW;
+      newHeight = minW / aspect;
+    }
+
+    // Centraliza o novo viewBox seguro no retângulo original
+    const cx = x + width / 2;
+    const cy = y + height / 2;
+
+    this.viewBox = {
+      x: cx - newWidth / 2,
+      y: cy - newHeight / 2,
+      width: newWidth,
+      height: newHeight,
+    };
     this.applyViewBox();
   }
 
@@ -136,22 +154,35 @@ export class CameraSVG {
   zoomOutFromRect(x, y, width, height) {
     if (!width || !height || width <= 0) return;
 
-    let scale = Math.max(
-      this.viewBox.width / width,
-      this.viewBox.height / height,
-    );
+    // 1. Pega a proporção física real da tela em pixels (Igual ao Zoom In)
+    const svgEl = this.svgs[0];
+    const screenWidth = svgEl.clientWidth || 800;
+    const screenHeight = svgEl.clientHeight || 600;
+    const aspect = screenWidth / screenHeight;
+
+    let adjustedWidth = width;
+    let adjustedHeight = height;
+
+    // 2. Ajusta o retângulo desenhado para casar com a proporção da tela
+    if (adjustedWidth / adjustedHeight > aspect) {
+      adjustedHeight = adjustedWidth / aspect;
+    } else {
+      adjustedWidth = adjustedHeight * aspect;
+    }
+
+    // 3. Calcula o fator de expansão do viewBox
+    // Se o usuário desenhou um retângulo que ocupa 20% da tela, o viewBox precisa crescer 5x
+    const scale = this.viewBox.width / adjustedWidth;
 
     let newWidth = this.viewBox.width * scale;
     let newHeight = this.viewBox.height * scale;
 
-    // Qual é a maior largura permitida (10% de zoom)?
+    // 4. Trava no limite máximo de distanciamento (Zoom Out mínimo, ex: 10%)
     const maxW = this.initialViewBox.width / (this.minZoomLimit / 100);
 
-    // Se a operação for afastar a tela além dos 10%:
     if (newWidth > maxW) {
-      scale = maxW / this.viewBox.width; // Recalcula escala limite
       newWidth = maxW;
-      newHeight = this.viewBox.height * scale;
+      newHeight = maxW / aspect;
     }
 
     this.viewBox = {

--- a/js/core/CameraSVG.js
+++ b/js/core/CameraSVG.js
@@ -5,19 +5,17 @@
 ============================================ */
 export class CameraSVG {
   constructor(svgs = []) {
-
     // Guardar um ou mais SVGs
     this.svgs = Array.isArray(svgs) ? svgs : [svgs];
 
-    const mainSVG = this.svgs[0]; 
-    const hasViewBox = mainSVG.hasAttribute('viewBox');
+    const mainSVG = this.svgs[0];
+    const hasViewBox = mainSVG.hasAttribute("viewBox");
 
     // Fallback: Evita valores zerados quando inicializado em display:none
     const fallbackWidth = mainSVG.clientWidth || 800;
     const fallbackHeight = mainSVG.clientHeight || 600;
 
     if (hasViewBox) {
-
       // Guarda valores base do viewbox atual (x,y,width,height)
       const vb = mainSVG.viewBox.baseVal;
 
@@ -26,39 +24,38 @@ export class CameraSVG {
         x: vb.width ? vb.x : 0,
         y: vb.height ? vb.y : 0,
         width: vb.width || fallbackWidth,
-        height: vb.height || fallbackHeight
+        height: vb.height || fallbackHeight,
       };
-
     } else {
-
       // Define um viewBox para o svg se não houver um
       this.viewBox = {
         x: 0,
         y: 0,
         width: fallbackWidth,
-        height: fallbackHeight
+        height: fallbackHeight,
       };
-      
     }
+    this.minZoomLimit = 10; // Trava o Zoom Out em 10%
+    this.maxZoomLimit = 4000; // Trava o Zoom In em 4000%
 
     // Guarda posição inicial do viewBox
-    this.initialViewBox = { ...this.viewBox }; 
+    this.initialViewBox = { ...this.viewBox };
     this.applyViewBox();
-    
   }
 
   // Aproxima o viewBox atual no SVG (aplica o "zoom")
   applyViewBox() {
     const { x, y, width, height } = this.viewBox;
 
-    // Proteção crucial: previne aplicação de viewBox que gera Matriz CTM singular
-    if (width === 0 || height === 0) return;
+    if (!isFinite(width) || !isFinite(height) || width <= 0 || height <= 0) {
+      return;
+    }
 
     const viewBoxValue = `${x} ${y} ${width} ${height}`;
 
     // aplica em todos os SVGs
-    this.svgs.forEach( (svg) => { 
-      svg.setAttribute('viewBox', viewBoxValue);
+    this.svgs.forEach((svg) => {
+      svg.setAttribute("viewBox", viewBoxValue);
     });
   }
 
@@ -66,7 +63,7 @@ export class CameraSVG {
   resetView() {
     this.viewBox = { ...this.initialViewBox };
     this.applyViewBox();
-  } 
+  }
 
   // Retorna o nivel atual de zoom em relação ao viewbox inicial
   getZoomLevel() {
@@ -78,43 +75,91 @@ export class CameraSVG {
   zoom(scale, cx, cy) {
     const old = this.viewBox;
 
-    const newWidth = old.width * scale;
-    const newHeight = old.height * scale;
-  
+    let newWidth = old.width * scale;
+    let newHeight = old.height * scale;
+
+    // Zoom In = viewBox menor / Zoom Out = viewBox maior
+    const minW = this.initialViewBox.width / (this.maxZoomLimit / 100);
+    const maxW = this.initialViewBox.width / (this.minZoomLimit / 100);
+
+    // Se passou do limite de aproximação (Zoom In)
+    if (newWidth < minW) {
+      if (old.width <= minW) return; // Já está no limite, ignora comando
+      scale = minW / old.width; // Força a escala a bater exato no limite
+      newWidth = minW;
+      newHeight = old.height * scale;
+    }
+    // Se passou do limite de distanciamento (Zoom Out)
+    else if (newWidth > maxW) {
+      if (old.width >= maxW) return; // Já está no limite, ignora comando
+      scale = maxW / old.width; // Força a escala a bater exato no limite
+      newWidth = maxW;
+      newHeight = old.height * scale;
+    }
+
     // Reposiciona o viewBox para manter o cursor fixo
     this.viewBox.x = cx - (cx - old.x) * (newWidth / old.width);
     this.viewBox.y = cy - (cy - old.y) * (newHeight / old.height);
-    
-    // Atualiza as dimensões do viewBox 
+
+    // Atualiza as dimensões do viewBox
     this.viewBox.width = newWidth;
     this.viewBox.height = newHeight;
 
     // aplica o zoom
     this.applyViewBox();
-  } 
+  }
 
   // Zoom-In -> Modo 'drag'
   zoomToRect(x, y, width, height) {
-    this.viewBox = {x, y, width, height};
+    if (!width || !height || width <= 0) return;
+
+    const minW = this.initialViewBox.width / (this.maxZoomLimit / 100);
+
+    // Se o usuário selecionou uma área minúscula que estouraria o limite:
+    if (width < minW) {
+      const correctionScale = minW / width;
+      const newW = minW;
+      const newH = height * correctionScale;
+
+      // Centraliza o novo viewBox seguro no retângulo original
+      x = x - (newW - width) / 2;
+      y = y - (newH - height) / 2;
+      width = newW;
+      height = newH;
+    }
+
+    this.viewBox = { x, y, width, height };
     this.applyViewBox();
   }
 
   // Zoom-Out -> Modo 'drag'
   zoomOutFromRect(x, y, width, height) {
-    const scale = Math.max(
+    if (!width || !height || width <= 0) return;
+
+    let scale = Math.max(
       this.viewBox.width / width,
-      this.viewBox.height / height
+      this.viewBox.height / height,
     );
-    const newWidth = this.viewBox.width * scale;
-    const newHeight = this.viewBox.height * scale;
+
+    let newWidth = this.viewBox.width * scale;
+    let newHeight = this.viewBox.height * scale;
+
+    // Qual é a maior largura permitida (10% de zoom)?
+    const maxW = this.initialViewBox.width / (this.minZoomLimit / 100);
+
+    // Se a operação for afastar a tela além dos 10%:
+    if (newWidth > maxW) {
+      scale = maxW / this.viewBox.width; // Recalcula escala limite
+      newWidth = maxW;
+      newHeight = this.viewBox.height * scale;
+    }
 
     this.viewBox = {
       x: x - (newWidth - width) / 2,
       y: y - (newHeight - height) / 2,
       width: newWidth,
-      height: newHeight
+      height: newHeight,
     };
     this.applyViewBox();
   }
-
 }

--- a/js/tools/LupaTool.js
+++ b/js/tools/LupaTool.js
@@ -222,6 +222,9 @@ export class LupaTool extends ToolBase {
 
     // Modo zoom por seleção ('drag')
     if (this.modo === "drag") {
+      // Previne dupla seleção e o congelamento decorrente dela
+      if (this.drag.active) return;
+
       this.drag.active = true;
       this.drag.start = coords;
       this.drag.button = evento.button;
@@ -253,7 +256,10 @@ export class LupaTool extends ToolBase {
   onMouseUp(evento) {
     evento.preventDefault();
 
-    if (!this.drag.active) return;
+    // Checa se o botão do capturado é o mesmo que iniciou a seleção
+    if (this.drag.active && evento.button !== this.drag.button) {
+      return;
+    }
 
     const coords = obterCoordenadaSVG(evento, this.svg);
     const x = Math.min(this.drag.start.x, coords.x);
@@ -293,12 +299,9 @@ export class LupaTool extends ToolBase {
     this.updateZoomIndicator();
   }
 
-  onMouseLeave(evento) {
-    if (!this.drag.active) {
-      return;
-    } else {
-      this.onMouseUp(evento);
-    }
+  onMouseLeave() {
+    if (!this.drag.active) return;
+    this.cleanupDrag();
   }
   /* ============================================
     Ciclo de Vida

--- a/js/tools/LupaTool.js
+++ b/js/tools/LupaTool.js
@@ -153,7 +153,10 @@ export class LupaTool extends ToolBase {
     const rect = document.createElementNS("http://www.w3.org/2000/svg", "rect");
     rect.setAttribute("fill", "rgba(0,0,255,0.15)");
     rect.setAttribute("stroke", "blue");
+    rect.setAttribute("stroke-width", "1");
     rect.setAttribute("stroke-dasharray", "4");
+    rect.setAttribute("vector-effect", "non-scaling-stroke");
+    rect.setAttribute("pointer-events", "none");
     this.overlaySvg.appendChild(rect);
     this.drag.rect = rect;
   }
@@ -196,6 +199,8 @@ export class LupaTool extends ToolBase {
 
   // Inicio da interação com o mouse
   onMouseDown(evento) {
+    evento.preventDefault();
+
     const coords = obterCoordenadaSVG(evento, this.svg);
 
     // Botão do meio ( Reset do viebox, independente do modo)
@@ -228,6 +233,8 @@ export class LupaTool extends ToolBase {
 
   // Atualiza retangulo de seleção em relação a posiçao
   onMouseMove(evento) {
+    evento.preventDefault();
+
     if (!this.drag.active || !this.drag.rect) return;
 
     const coords = obterCoordenadaSVG(evento, this.svg);
@@ -254,24 +261,24 @@ export class LupaTool extends ToolBase {
     const width = Math.abs(coords.x - this.drag.start.x);
     const height = Math.abs(coords.y - this.drag.start.y);
 
+    const acaoBotao = this.drag.button;
+    this.cleanupDrag();
+
     // Ignora seleções muito pequenas
-    if (width < 5 || height < 5) {
-      this.cleanupDrag();
+    if (width === 0 || height === 0) {
       return;
     }
 
     // Zoom In
-    if (evento.button === 0) {
+    if (acaoBotao === 0) {
       this.camera.zoomToRect(x, y, width, height);
     }
 
     // Zoom Out
-    if (evento.button === 2) {
+    if (acaoBotao === 2) {
       this.camera.zoomOutFromRect(x, y, width, height);
     }
-
     this.updateZoomIndicator();
-    this.cleanupDrag();
   }
 
   // Interação do scroll do mouse (zoom conforme movimento do scroll)
@@ -286,6 +293,13 @@ export class LupaTool extends ToolBase {
     this.updateZoomIndicator();
   }
 
+  onMouseLeave(evento) {
+    if (!this.drag.active) {
+      return;
+    } else {
+      this.onMouseUp(evento);
+    }
+  }
   /* ============================================
     Ciclo de Vida
   ============================================ */
@@ -293,7 +307,9 @@ export class LupaTool extends ToolBase {
   // Ativa ferramenta, exibe painel de opcoes do zoom e o Indicador de Zoom
   onAtivar() {
     this._wheelHandler = (e) => this.onWheel(e);
+    this._leaveHandler = (e) => this.onMouseLeave(e);
     this.svg.addEventListener("wheel", this._wheelHandler, { passive: false });
+    this.svg.addEventListener("mouseleave", this._leaveHandler);
     this.openPanel();
     this.updateCursor();
     this.updateZoomIndicator();
@@ -305,7 +321,10 @@ export class LupaTool extends ToolBase {
       this.svg.removeEventListener("wheel", this._wheelHandler);
       this._wheelHandler = null;
     }
-
+    if (this._leaveHandler) {
+      this.svg.removeEventListener("mouseleave", this._leaveHandler);
+      this._leaveHandler = null;
+    }
     this.cleanupDrag();
     this.closePanel();
 

--- a/js/tools/LupaTool.js
+++ b/js/tools/LupaTool.js
@@ -1,7 +1,6 @@
-import { ToolBase } from './ToolBase.js';
-import { obterCoordenadaSVG } from '../utils/svgHelpers.js';
-import { CameraSVG } from '../core/CameraSVG.js';
-
+import { ToolBase } from "./ToolBase.js";
+import { obterCoordenadaSVG } from "../utils/svgHelpers.js";
+import { CameraSVG } from "../core/CameraSVG.js";
 
 /* ============================================
                   LupaTool
@@ -14,60 +13,60 @@ export class LupaTool extends ToolBase {
     this.overlaySvg = overlaySvg;
     this.camera = camera || new CameraSVG([svg, overlaySvg]);
 
-    this.modo = 'click'; // zoom padrão do inkscape
+    this.modo = "click"; // zoom padrão do inkscape
 
     // controles da interação mouseOnMove | Modo drag
     this.drag = {
-      active: false,  // se 
-      start: null,    // 
-      button: null,   // 
-      rect: null      // 
-    }; 
+      active: false, // se
+      start: null, //
+      button: null, //
+      rect: null, //
+    };
+
+    this.zoomInFactor = 0.95;
+    this.zoomOutFactor = 1 / this.zoomInFactor;
+
+    this.minZoomLimit = this.camera.minZoomLimit; // Trava o Zoom Out em 10%
+    this.maxZoomLimit = this.camera.maxZoomLimit; // Trava o Zoom In em 4000%
   }
-  
+
   /* ============================================
     Interface e Butoes
   ============================================ */
 
   // Atualiza o indicador de acordo com o nivel de zoom
   updateZoomIndicator() {
-    const el = document.getElementById('zoom-indicator');
+    const el = document.getElementById("zoom-indicator");
     if (!el) return;
     el.textContent = `Zoom: ${this.camera.getZoomLevel()}%`;
   }
 
   // Atualiza o cursos de acordo com o modo
   updateCursor() {
-    this.svg.style.cursor = 
-      this.modo === 'drag' 
-      ? 'crosshair' 
-      : 'zoom-in';
+    this.svg.style.cursor = this.modo === "drag" ? "crosshair" : "zoom-in";
   }
 
   // Atualiza o btn-drag quando pressionado
   updateButtons() {
-    const btnDrag = document.getElementById('btn-drag');
+    const btnDrag = document.getElementById("btn-drag");
     if (!btnDrag) return;
-    btnDrag.classList.toggle('ativo', this.modo === 'drag');
+    btnDrag.classList.toggle("ativo", this.modo === "drag");
 
-    const nomeEl = document.getElementById('nome-ferramenta');
-    if (nomeEl) 
-      nomeEl.textContent = this.modo === 'drag' ? 'Zoom por Seleção' : 'Zoom';
+    const nomeEl = document.getElementById("nome-ferramenta");
+    if (nomeEl)
+      nomeEl.textContent = this.modo === "drag" ? "Zoom por Seleção" : "Zoom";
   }
 
-
-  // Alterna o modo de interação da lupa 
+  // Alterna o modo de interação da lupa
   setModo(modo) {
-    this.modo = (this.modo === modo) ? 'click' : modo;
+    this.modo = this.modo === modo ? "click" : modo;
     this.updateCursor();
     this.updateButtons();
-  } 
+  }
 
-
-  // Renderiza dinamicamente o painel de opcoes da lupa 
+  // Renderiza dinamicamente o painel de opcoes da lupa
   renderOptions() {
-    const panel =
-      document.getElementById('zoom-options');
+    const panel = document.getElementById("zoom-options");
 
     if (!panel || panel.dataset.initialized) return;
 
@@ -78,7 +77,7 @@ export class LupaTool extends ToolBase {
         class="btn-ferramenta"
         data-tooltip="Zoom por Seleção (Shift+Z)">
 
-        <svg 
+        <svg
           xmlns="http://www.w3.org/2000/svg"
           width="22"
           height="22"
@@ -87,16 +86,16 @@ export class LupaTool extends ToolBase {
           stroke="currentColor"
           stroke-width="2">
 
-          <circle 
-            cx="10" 
-            cy="10" 
+          <circle
+            cx="10"
+            cy="10"
             r="8">
           </circle>
 
-          <line 
-            x1="20" 
-            y1="20" 
-            x2="15" 
+          <line
+            x1="20"
+            y1="20"
+            x2="15"
             y2="15">
           </line>
 
@@ -111,17 +110,17 @@ export class LupaTool extends ToolBase {
       </button>
     `;
     // Atualiza o modo para 'drag' quando pressionado
-    panel.querySelector('#btn-drag').onclick = () => {
-      this.setModo('drag');
+    panel.querySelector("#btn-drag").onclick = () => {
+      this.setModo("drag");
     };
     // Define que o painel existe (visivel)
-    panel.dataset.initialized = 'true';
+    panel.dataset.initialized = "true";
     this.updateButtons();
-  } 
-  
+  }
+
   // Cria e posiciona o painel em relação ao 'btn-Lupa' da main.js
   openPanel() {
-    const panel = document.getElementById('zoom-options');
+    const panel = document.getElementById("zoom-options");
     const btnLupa = document.querySelector('[data-ferramenta="lupa"]');
 
     if (!panel || !btnLupa) return;
@@ -131,21 +130,19 @@ export class LupaTool extends ToolBase {
     panel.style.top = `${rect.top}px`;
     panel.style.left = `${rect.right + 8}px`;
 
-    panel.classList.remove('hidden');
+    panel.classList.remove("hidden");
 
     this.renderOptions();
-
   }
 
   // Destroi o painel de opções (oculto)
   closePanel() {
-    const panel = document.getElementById('zoom-options');
+    const panel = document.getElementById("zoom-options");
     if (!panel) return;
-    panel.classList.add('hidden');
-    panel.innerHTML = '';
+    panel.classList.add("hidden");
+    panel.innerHTML = "";
     delete panel.dataset.initialized;
   }
-
 
   /* ============================================
     Retangulo Selecao
@@ -153,16 +150,15 @@ export class LupaTool extends ToolBase {
 
   // Define o retangulo de seleção
   createSelectionRect() {
-    const rect = document.createElementNS(
-      'http://www.w3.org/2000/svg','rect');
-    rect.setAttribute('fill', 'rgba(0,0,255,0.15)');
-    rect.setAttribute('stroke','blue');
-    rect.setAttribute('stroke-dasharray','4');
+    const rect = document.createElementNS("http://www.w3.org/2000/svg", "rect");
+    rect.setAttribute("fill", "rgba(0,0,255,0.15)");
+    rect.setAttribute("stroke", "blue");
+    rect.setAttribute("stroke-dasharray", "4");
     this.overlaySvg.appendChild(rect);
     this.drag.rect = rect;
   }
 
-  // Remove elemento retangulo de seleção e reseta o estado/modo da lupa 
+  // Remove elemento retangulo de seleção e reseta o estado/modo da lupa
   cleanupDrag() {
     if (this.drag.rect && this.drag.rect.parentNode) {
       this.drag.rect.parentNode.removeChild(this.drag.rect);
@@ -171,18 +167,37 @@ export class LupaTool extends ToolBase {
       active: false,
       start: null,
       button: null,
-      rect: null
+      rect: null,
     };
-  } 
-  
+  }
+
   /* ============================================
     Eventos
   ============================================ */
 
-  // Inicio da interação com o mouse 
+  // Bloqueia a requisição de zoom se já estivermos nos limites
+  requestZoom(scale, x, y) {
+    const currentZoom = this.camera.getZoomLevel();
+
+    // Se scale < 1, é Zoom In (aproximação do viewBox)
+    if (scale < 1 && currentZoom >= this.maxZoomLimit) {
+      return; // Ignora o comando
+    }
+
+    // Se scale > 1, é Zoom Out (afastamento do viewBox)
+    if (scale > 1 && currentZoom <= this.minZoomLimit) {
+      return; // Ignora o comando
+    }
+
+    // Se passou pela verificação, aplica o zoom livremente
+    this.camera.zoom(scale, x, y);
+    this.updateZoomIndicator();
+  }
+
+  // Inicio da interação com o mouse
   onMouseDown(evento) {
     const coords = obterCoordenadaSVG(evento, this.svg);
-  
+
     // Botão do meio ( Reset do viebox, independente do modo)
     if (evento.button === 1) {
       this.camera.resetView();
@@ -190,25 +205,26 @@ export class LupaTool extends ToolBase {
       return;
     }
 
-    // Modo zoom padrão ('click') 
-    if (this.modo === 'click') {
-      if (evento.button === 0) this.camera.zoom(0.9, coords.x, coords.y);
-      if (evento.button === 2) this.camera.zoom(1.1, coords.x, coords.y);
+    // Modo zoom padrão ('click')
+    if (this.modo === "click") {
+      if (evento.button === 0)
+        this.requestZoom(this.zoomInFactor, coords.x, coords.y);
+      if (evento.button === 2)
+        this.requestZoom(this.zoomOutFactor, coords.x, coords.y);
       this.updateZoomIndicator();
       return;
-    } 
+    }
 
     // Modo zoom por seleção ('drag')
-    if (this.modo === 'drag') {
-      this.drag.active= true;
+    if (this.modo === "drag") {
+      this.drag.active = true;
       this.drag.start = coords;
       this.drag.button = evento.button;
 
       // Cria retangulo de seleção
       this.createSelectionRect();
-    } 
-  } 
-  
+    }
+  }
 
   // Atualiza retangulo de seleção em relação a posiçao
   onMouseMove(evento) {
@@ -220,12 +236,11 @@ export class LupaTool extends ToolBase {
     const width = Math.abs(coords.x - this.drag.start.x);
     const height = Math.abs(coords.y - this.drag.start.y);
 
-    this.drag.rect.setAttribute('x', x);
-    this.drag.rect.setAttribute('y', y);
-    this.drag.rect.setAttribute('width', width);
-    this.drag.rect.setAttribute('height', height);
-  } 
-
+    this.drag.rect.setAttribute("x", x);
+    this.drag.rect.setAttribute("y", y);
+    this.drag.rect.setAttribute("width", width);
+    this.drag.rect.setAttribute("height", height);
+  }
 
   // Finaliza zoom de seleção e aplica zoom
   onMouseUp(evento) {
@@ -233,7 +248,7 @@ export class LupaTool extends ToolBase {
 
     if (!this.drag.active) return;
 
-    const coords = obterCoordenadaSVG(evento,this.svg);
+    const coords = obterCoordenadaSVG(evento, this.svg);
     const x = Math.min(this.drag.start.x, coords.x);
     const y = Math.min(this.drag.start.y, coords.y);
     const width = Math.abs(coords.x - this.drag.start.x);
@@ -244,31 +259,30 @@ export class LupaTool extends ToolBase {
       this.cleanupDrag();
       return;
     }
-    
+
     // Zoom In
     if (evento.button === 0) {
       this.camera.zoomToRect(x, y, width, height);
     }
 
-    // Zoom Out 
-    if (evento.button === 2) { 
-      this.camera.zoomOutFromRect(x,y,width,height);
+    // Zoom Out
+    if (evento.button === 2) {
+      this.camera.zoomOutFromRect(x, y, width, height);
     }
-
 
     this.updateZoomIndicator();
     this.cleanupDrag();
-  } 
+  }
 
   // Interação do scroll do mouse (zoom conforme movimento do scroll)
   onWheel(evento) {
     evento.preventDefault();
     const coords = obterCoordenadaSVG(evento, this.svg);
-    const zoomFactor = 0.1;
-    const scale = evento.deltaY > 0
-      ? 1 + zoomFactor      // scroll-up = zoom-in
-      : 1 - zoomFactor;     // scroll-down = zoom-out
-    this.camera.zoom(scale, coords.x, coords.y);
+    const scale =
+      evento.deltaY > 0
+        ? this.zoomOutFactor // scroll-up = zoom-in
+        : this.zoomInFactor; // scroll-down = zoom-out
+    this.requestZoom(scale, coords.x, coords.y);
     this.updateZoomIndicator();
   }
 
@@ -277,28 +291,25 @@ export class LupaTool extends ToolBase {
   ============================================ */
 
   // Ativa ferramenta, exibe painel de opcoes do zoom e o Indicador de Zoom
-  onAtivar() { 
+  onAtivar() {
     this._wheelHandler = (e) => this.onWheel(e);
-    this.svg.addEventListener('wheel', this._wheelHandler, {passive: false});
+    this.svg.addEventListener("wheel", this._wheelHandler, { passive: false });
     this.openPanel();
     this.updateCursor();
     this.updateZoomIndicator();
-  } 
-
+  }
 
   // Desativa ferramenta, limpa UI, retorna para o modo padrão
   onDesativar() {
     if (this._wheelHandler) {
-      this.svg.removeEventListener('wheel', this._wheelHandler);
+      this.svg.removeEventListener("wheel", this._wheelHandler);
       this._wheelHandler = null;
     }
 
     this.cleanupDrag();
     this.closePanel();
 
-    this.setModo('click');
-    this.svg.style.cursor = 'default';
-  } 
-} 
-
-
+    this.setModo("click");
+    this.svg.style.cursor = "default";
+  }
+}


### PR DESCRIPTION
# Pull Request: [FIX] Reversibilidade de Zoom, Limites de Câmera e Correção do Zoom por Drag

## Descrição e Contexto

Esta PR resolve o problema de drift acumulativo nos fatores de zoom-in/zoom-out tornando-os matematicamente inversos. Além disso, introduz tratamentos de segurança para os limites de escala (10% a 4000%) e corrige o bug de travamento/congelamento visual do retângulo de seleção (`drag-zoom`) quando interage com limites máximos ou sai das bordas do SVG canvas.

---

##  Alterações Realizadas

### 1. Consistência Matemática do Fator de Zoom (`LupaTool.js`)
* **Reversibilidade:** Substituído o uso de incrementos empíricos fixos por inverso multiplicativo:
  $$\text{zoomInFactor} = 0.95 \quad \Longrightarrow \quad \text{zoomOutFactor} = \frac{1}{0.95} \approx 1.0526$$
  Isso garante que aplicar zoom-in seguido de zoom-out retorne o viewBox **exatamente** para o estado anterior, eliminando o acúmulo de drift de escala.
* Aplicado uniformemente no clique, roda do mouse (`onWheel`) e atalhos.

### 2. Correção de Eventos e Bug de Congelamento do Retângulo (`LupaTool.js`)
* **Pointer Events:** Adicionado `pointer-events: none` dinamicamente no SVG do retângulo de seleção (`createSelectionRect`). Isso evita que o próprio overlay intercepte o movimento do mouse e interrompa o ciclo de eventos.
* **Tratamento de Fuga do Mouse (`onMouseLeave`):** Implementado listener para quando o cursor do mouse sai do limite inferior/externo do canvas. O método captura a borda e dispara de forma segura o `onMouseUp(evento)` aplicando o zoom máximo até aquele limite, limpando o drag do DOM corretamente sem congelá-lo.

### 3. Melhoria de Robustez no Enquadramento do ViewBox (`CameraSVG.js`)
* **Aspect Ratio Físico:** Os métodos `zoomToRect` e `zoomOutFromRect` agora buscam dinamicamente o `clientWidth` e `clientHeight` real do SVG do contêiner. Isso assegura que a distorção proporcional funcione com precisão milimétrica, independente de redimensionamentos de tela.
* **Estouro de Limites:** Se a área de seleção for menor/maior que o limite configurado (10% - 4000%), a câmera é configurada perfeitamente no limite mínimo/máximo preservando a proporção geométrica, centralizando o viewport exatamente no ponto central da seleção do usuário.

---

##  Critérios de Aceite Atendidos

- [x] Zoom-in seguido de zoom-out retorna exatamente ao mesmo nível percentual anterior.
- [x] Roda do mouse (`wheel`) livre de drifts cumulativos.
- [x] O retângulo de seleção azul não congela mais ao arrastar rápido, tocar as bordas inferiores ou se aproximar do zoom máximo (4000%).
- [x] A transição de saída do mouse (`mouseleave`) gera o zoom correspondente de forma elegante até a borda.
- [x] Limites de Zoom Superior (4000%) e Inferior (10%) travam suavemente sem deformar a proporção ou quebrar o viewBox.

---

## Como Testar

1. Selecione a ferramenta **Lupa**.
2. No modo clique, verifique no indicador de status que realizar 5 cliques com o Botão Esquerdo (Zoom In) seguidos de 5 cliques com o Botão Direito (Zoom Out) faz o indicador retornar precisamente para os **100%** originais.
3. Alterne para o modo **Zoom por Seleção** (`drag`).
4. Arraste um retângulo minúsculo de seleção até encostar na barra inferior ou lateral da janela do navegador. Verifique que o zoom é processado sem que o quadrado azul permaneça travado na tela.

## Esperando Revisão
@Savio-Miranda 
@Julio-C-Oliveira 
@luiz2801 