### PR TITLE
[Feature] Adicionando atalhos para copiar e colar

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -20,9 +20,6 @@ import {
   refazerAcao,
   registrarAcaoHistorico,
   atualizarPosicaoSelecaoVisual
-  definirCallbackPainelAlinhamento,
-  atualizarPosicaoSelecaoVisual,
-  definirEspessuraLapis
 } from './core/StateManager.js';
 import { ColorPickerTool } from './tools/ColorPickerTool.js';
 import { Lapis } from './tools/LapisTool.js';
@@ -54,18 +51,6 @@ import { Regua } from './core/Regua.js';
 import { LosangoTool } from './tools/LosangoTool.js';
 import { agruparElementos, desagruparElementos } from './core/GroupManager.js';
 import { espelharHorizontal, espelharVertical } from "./utils/flipHelpers.js";
-import {
-  alinharEsquerda,
-  alinharCentroHorizontal,
-  alinharDireita,
-  alinharTopo,
-  alinharCentroVertical,
-  alinharBase,
-  distribuirHorizontalmente,
-  distribuirVerticalmente,
-} from './utils/alignHelpers.js';
-import { salvarRascunho, marcarSalvo } from './utils/autoSave.js';
-import { ImageTracerManager } from './tools/ImageTracerManager.js';
 
 const svgCanvas = document.getElementById('canvas');
 
@@ -173,11 +158,11 @@ canvasContainer.appendChild(svgCanvas);
 // Camada de Interação: instanciar o novo SVG de overlay para seleções
 const overlayCanvas = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
 overlayCanvas.setAttribute('id', 'overlay-canvas');
+overlayCanvas.setAttribute('width', '100%');
+overlayCanvas.setAttribute('height', '100%');
 overlayCanvas.style.position = 'absolute';
-overlayCanvas.style.top = '20px';
-overlayCanvas.style.left = '20px';
-overlayCanvas.style.width = 'calc(100% - 20px)';
-overlayCanvas.style.height = 'calc(100% - 20px)';
+overlayCanvas.style.top = '0';
+overlayCanvas.style.left = '0';
 overlayCanvas.style.pointerEvents = 'none'; // Coordenado com o principal
 canvasContainer.appendChild(overlayCanvas);
 
@@ -210,21 +195,6 @@ observer.observe(svgCanvas, { attributes: true, attributeFilter: ['viewBox'] });
 const selecaoVisual = new Selecao(overlayCanvas);
 definirGerenciadorSelecao(selecaoVisual);
 
-// --- Painel de Alinhamento (multi-seleção) ---
-const painelAlinhamento = document.getElementById('painel-alinhamento');
-function atualizarVisibilidadePainelAlinhamento(qtd) {
-  if (!painelAlinhamento) return;
-  if (qtd >= 2) {
-    painelAlinhamento.classList.remove('oculto');
-  } else {
-    painelAlinhamento.classList.add('oculto');
-  }
-}
-definirCallbackPainelAlinhamento(atualizarVisibilidadePainelAlinhamento);
-
-// Menu de contexto simples em utilitário
-inicializarMenuContexto(svgCanvas);
-
 // Instâncias das ferramentas disponíveis com todas as implementações da main
 const cameraGlobal = new CameraSVG([svgCanvas, overlayCanvas]);
 const scrollbar = new ScrollbarSVG(canvasContainer, svgCanvas, cameraGlobal);
@@ -250,7 +220,7 @@ const instanciasFerramentas = {
 /**
  * Atualiza o estado visual dos botões da sidebar,
  * destacando apenas o botão da ferramenta ativa.
- * 
+ *
  * @param {string} nomeDaFerramenta - Identificador da ferramenta ativa.
  */
 function atualizarBotaoAtivo(nomeDaFerramenta) {
@@ -333,9 +303,11 @@ svgCanvas.addEventListener('mouseup', (evento) => {
   if (primeiroSelecionado) {
     const corPreenchimentoAtual = primeiroSelecionado.getAttribute('fill') || '#ffffff';
     const corBordaAtual = primeiroSelecionado.getAttribute('stroke') || '#000000';
-    // Captura as opacidades existentes (padrão é 1 se não houver atributo)    
+    
+    // Captura as opacidades existentes (padrão é 1 se não houver atributo)
     const opacidadePreenchimentoAtual = primeiroSelecionado.getAttribute('fill-opacity') || '1';
     const opacidadeBordaAtual = primeiroSelecionado.getAttribute('stroke-opacity') || '1';
+
     // Só atualizamos os seletores visuais do HTML se o valor do SVG for uma cor hexadecimal válida.
     if (corPreenchimentoAtual !== 'none' && corPreenchimentoAtual.startsWith('#')) {
       inputCorPreenchimento.value = corPreenchimentoAtual;
@@ -343,10 +315,11 @@ svgCanvas.addEventListener('mouseup', (evento) => {
     if (corBordaAtual !== 'none' && corBordaAtual.startsWith('#')) {
       inputCorBorda.value = corBordaAtual;
     }
-    
+
     // Atualiza visualmente os Sliders de Opacidade na UI
     sliderOpacidadePreenchimento.value = opacidadePreenchimentoAtual;
     sliderOpacidadeBorda.value = opacidadeBordaAtual;
+
     // Atualiza também os valores armazenados no StateManager para consistência
     definirCorPreenchimento(corPreenchimentoAtual);
     definirCorBorda(corBordaAtual);
@@ -355,36 +328,43 @@ svgCanvas.addEventListener('mouseup', (evento) => {
 
 btnPreenchimentoNenhum.addEventListener('click', () => {
   definirCorPreenchimento('none');
+  
   estado.elementosSelecionados.forEach(el => {
     el.setAttribute('fill', 'none');
   });
+  
   registrarAcaoHistorico();
   atualizarBotoesHistorico();
 });
 
 btnBordaNenhum.addEventListener('click', () => {
   definirCorBorda('none');
+  
   estado.elementosSelecionados.forEach(el => {
     el.setAttribute('stroke', 'none');
   });
+  
   registrarAcaoHistorico();
   atualizarBotoesHistorico();
 });
 
 sliderOpacidadePreenchimento.addEventListener('input', () => {
   const valor = sliderOpacidadePreenchimento.value;
+  
   estado.elementosSelecionados.forEach(el => {
     el.setAttribute('fill-opacity', valor);
   });
 });
 
 sliderOpacidadePreenchimento.addEventListener('change', () => {
+  // Salva no histórico apenas quando o usuário soltar o slider
   registrarAcaoHistorico();
   atualizarBotoesHistorico();
 });
 
 sliderOpacidadeBorda.addEventListener('input', () => {
   const valor = sliderOpacidadeBorda.value;
+  
   estado.elementosSelecionados.forEach(el => {
     el.setAttribute('stroke-opacity', valor);
   });
@@ -427,9 +407,6 @@ overlayCanvas.addEventListener('mouseup', (evento) => {
   if (estado.ferramentaAtual) {
     estado.ferramentaAtual.onMouseUp(evento);
   }
-  // Auto-save silencioso após ações realizadas via overlay (ex: mover seleções, lápis)
-  salvarRascunho(svgCanvas, estado, 'editor');
-  mostrarIndicadorNaoSalvo();
 });
 
 // Previne o menu de opções do botão direito no canvas
@@ -455,7 +432,7 @@ const valorEspessura =
 
 inputEspessuraLapis.addEventListener("input", (e) => {
     definirEspessuraLapis(e.target.value);
-    if (valorEspessura) valorEspessura.textContent = e.target.value;
+    valorEspessura.textContent = e.target.value;
 });
 
 // --- Controle de Camadas (Z-Index) ---
@@ -671,20 +648,6 @@ btnImportarImagem.addEventListener('click', () => {
 
 inicializarImportadorImagem(svgCanvas, inputImagem);
 
-// --- Inicialização do ImageTracer ---
-const tracerManager = new ImageTracerManager(svgCanvas, inputImagem);
-// Assiste a aba do Tracer para atualizar a lista de imagens quando ela for ativada
-const tabTracer = document.getElementById('tab-tracer');
-if (tabTracer) {
-    const observerTab = new MutationObserver(() => {
-      // Verifica se a classe 'ativo' foi adicionada pela SideBar.js
-        if (tabTracer.classList.contains('ativo')) {
-            tracerManager.atualizarLista();
-        }
-    });
-    observerTab.observe(tabTracer, { attributes: true, attributeFilter: ['class'] });
-}
-
 // Inicializar o estado dos botões de histórico
 atualizarBotoesHistorico();
 
@@ -702,37 +665,3 @@ svgCanvas.addEventListener('wheel', (e) => {
   cameraGlobal.zoom(escala, coords.x, coords.y);
   scrollbar.atualizar();
 }, { passive: false });
-}, { passive: false });
-
-// --- Botões de Alinhamento ---
-function executarAlinhamento(fn) {
-  fn(estado.elementosSelecionados);
-  atualizarPosicaoSelecaoVisual();
-  registrarAcaoHistorico();
-  atualizarBotoesHistorico();
-}
-
-// Com encadeamento opcional (?) caso os botões não existam em outras views
-document.getElementById('btn-alinhar-esquerda')?.addEventListener('click', () => executarAlinhamento(alinharEsquerda));
-document.getElementById('btn-alinhar-centro-h')?.addEventListener('click', () => executarAlinhamento(alinharCentroHorizontal));
-document.getElementById('btn-alinhar-direita')?.addEventListener('click',  () => executarAlinhamento(alinharDireita));
-document.getElementById('btn-alinhar-topo')?.addEventListener('click',     () => executarAlinhamento(alinharTopo));
-document.getElementById('btn-alinhar-centro-v')?.addEventListener('click', () => executarAlinhamento(alinharCentroVertical));
-document.getElementById('btn-alinhar-base')?.addEventListener('click',     () => executarAlinhamento(alinharBase));
-document.getElementById('btn-distribuir-h')?.addEventListener('click',     () => executarAlinhamento(distribuirHorizontalmente));
-document.getElementById('btn-distribuir-v')?.addEventListener('click',     () => executarAlinhamento(distribuirVerticalmente));
-
-// Observa o canvas para atualizar o Tracer automaticamente quando uma imagem for adicionada ou removida
-const observerCanvas = new MutationObserver((mutations) => {
-    mutations.forEach((mutation) => {
-        if (mutation.addedNodes.length > 0 || mutation.removedNodes.length > 0) {
-          // Verifica se a aba do tracer está aberta no momento
-            if (tabTracer && tabTracer.classList.contains('ativo')) {
-                tracerManager.atualizarLista();
-            }
-        }
-    });
-});
-
-// Começa a observar a adição/remoção de elementos filhos no svgCanvas
-observerCanvas.observe(svgCanvas, { childList: true });

--- a/js/main.js
+++ b/js/main.js
@@ -545,6 +545,11 @@ window.addEventListener("keydown", (e) => {
       atualizarBotoesHistorico();
       return;
     }
+    // Ctrl+C / Ctrl+V / Ctrl+D são tratados em outro listener — apenas impede
+    // que caiam no mapa de atalhos de ferramenta abaixo.
+    if (['c', 'v', 'd'].includes(e.key.toLowerCase())) {
+      return;
+    }
   }
 
   const mapaTeclas = {
@@ -575,6 +580,11 @@ window.addEventListener("keydown", (e) => {
   }
 });
 
+// --- Área de Transferência (Copiar / Colar) ---
+let clipboard = [];       
+let pasteCount = 0;       
+const PASTE_OFFSET = 20;  
+
 // --- Duplicar elemento ---
 function handlerDuplicar() {
   const el = estado.elementosSelecionados[0];
@@ -587,9 +597,47 @@ function handlerDuplicar() {
 }
 
 document.addEventListener('keydown', (evento) => {
-  if ((evento.ctrlKey || evento.metaKey) && evento.key.toLowerCase() === 'd') {
+  if (!(evento.ctrlKey || evento.metaKey)) return;
+
+  const tecla = evento.key.toLowerCase();
+
+  // Ctrl+D — Duplicar
+  if (tecla === 'd') {
     evento.preventDefault();
     handlerDuplicar();
+    return;
+  }
+
+  // Ctrl+C — Copiar elementos selecionados para a área de transferência interna
+  if (tecla === 'c') {
+    if (estado.elementosSelecionados.length === 0) return;
+    evento.preventDefault();
+    clipboard = estado.elementosSelecionados.map(el => el.cloneNode(true));
+    pasteCount = 0;
+    return;
+  }
+
+  // Ctrl+V — Colar elementos da área de transferência interna
+  if (tecla === 'v') {
+    if (clipboard.length === 0) return;
+    evento.preventDefault();
+    pasteCount++;
+    const offset = PASTE_OFFSET * pasteCount;
+    const novosElementos = [];
+
+    clipboard.forEach(original => {
+      const clone = duplicarElemento(original, svgCanvas, offset, offset);
+      if (clone) {
+        novosElementos.push(clone);
+      }
+    });
+
+    if (novosElementos.length > 0) {
+      definirElementosSelecionados(novosElementos);
+      registrarAcaoHistorico();
+      atualizarBotoesHistorico();
+    }
+    return;
   }
 });
 

--- a/js/main.js
+++ b/js/main.js
@@ -516,13 +516,15 @@ btnFlipVertical.addEventListener("click", () => {
 });
 
 // Atalhos de Teclado (Tool Selection)
+// Atalhos de Teclado (Tool Selection)
 window.addEventListener("keydown", (e) => {
-  // Prevenção de conflitos
+  // Prevenção de conflitos (ignora atalhos se estiver digitando em campos de texto)
   const elementoAtivo = document.activeElement;
-  const tagAtiva = elementoAtivo.tagName.toLocaleLowerCase();
+  const tagAtiva = elementoAtivo.tagName.toLowerCase();
 
-  if (["input", "textarea", "select"].includes(tagAtiva) || elementoAtivo.isContentEditable)
+  if (["input", "textarea", "select"].includes(tagAtiva) || elementoAtivo.isContentEditable) {
     return;
+  }
 
   // 1. Agrupamos TODA lógica que depende obrigatoriamente de Ctrl / Cmd
   if (e.ctrlKey || e.metaKey) {
@@ -555,30 +557,39 @@ window.addEventListener("keydown", (e) => {
       return;
     }
     
-    // Agora este bloqueio está protegido dentro do bloco "if (e.ctrlKey || e.metaKey)"
-    // Ele impede que Ctrl+C, Ctrl+V ou Ctrl+D vazem para o mapa de ferramentas abaixo,
-    // mas não interfere quando as teclas C, V ou D são pressionadas sozinhas!
+    // Impede que Ctrl+C, Ctrl+V ou Ctrl+D acionem as ferramentas normais
     if (['c', 'v', 'd'].includes(teclaCtrl)) {
       return;
     }
   }
 
-  // --- LÓGICA DE DELEÇÃO CORRIGIDA ---
-    if (e.key === ']' || e.key === '}') {
-      e.preventDefault();
-      moverCamada(e.shiftKey ? 'frente' : 'avancar');
-      return;
+  // --- LÓGICA DE REORGANIZAÇÃO DE CAMADAS ---
+  if (e.key === ']' || e.key === '}') {
+    e.preventDefault();
+    moverCamada(e.shiftKey ? 'frente' : 'avancar');
+    return;
+  }
+  if (e.key === '[' || e.key === '{') {
+    e.preventDefault();
+    moverCamada(e.shiftKey ? 'fundo' : 'recuar');
+    return;
+  }
+
+  // --- LÓGICA DE DELEÇÃO ---
+  if (e.key === "Delete" || e.key === "Backspace") {
+    if (estado.elementosSelecionados && estado.elementosSelecionados.length > 0) {
+      estado.elementosSelecionados.forEach(el => el.remove());
+      definirElementosSelecionados([]);
+      atualizarPosicaoSelecaoVisual();
+      registrarAcaoHistorico();
+      atualizarBotoesHistorico();
     }
-    if (e.key === '[' || e.key === '{') {
-      e.preventDefault();
-      moverCamada(e.shiftKey ? 'fundo' : 'recuar');
-      return;
-    }
+    return;
   }
 
   const teclaPressionada = e.key.toLowerCase();
 
-  // Atalhos com Shift
+  // --- ATALHOS COM SHIFT ---
   if (e.shiftKey) {
     const mapaTeclasShift = {
       "c": "bezier",
@@ -619,6 +630,7 @@ window.addEventListener("keydown", (e) => {
     return;
   }
 
+  // --- ATALHOS SIMPLES (TECLAS ISOLADAS) ---
   const mapaTeclas = {
     "s" : "selecao",
     "r" : "retangulo",
@@ -634,39 +646,9 @@ window.addEventListener("keydown", (e) => {
     "z" : "lupa",
     "d" : "pincel",
     "h" : "losango",
-  }
-
-  // --- LÓGICA DE DELEÇÃO ---
-  if (e.key === "Delete" || e.key === "Backspace") {
-    if (estado.elementosSelecionados && estado.elementosSelecionados.length > 0) {
-      estado.elementosSelecionados.forEach(el => el.remove());
-      definirElementosSelecionados([]);
-      atualizarPosicaoSelecaoVisual();
-      registrarAcaoHistorico();
-      atualizarBotoesHistorico();
-    }
-    return;
-  }
-
-  // 2. Se chegou aqui e Ctrl/Cmd NÃO está ativo, as teclas isoladas seguem normalmente para as ferramentas
-  const mapaTeclas = {
-    "s" : "selecao",
-    "r" : "retangulo",
-    "e" : "elipse",
-    "l" : "linha",
-    "c" : "linhaCurvada", // Agora funciona livremente ao digitar "C" sozinho!
-    "p" : "poligono",
-    "t" : "texto",
-    "i" : "Conta-gotas",
-    "g" : "losango",
   };
 
-  const teclaPressionada = e.key.toLowerCase();
-  const ferramentaAlvo = e.shiftKey && teclaPressionada === 'c'
-    ? 'bezier'
-    : e.shiftKey && teclaPressionada === 'e'
-      ? 'espiral'
-    : mapaTeclas[teclaPressionada];
+  const ferramentaAlvo = mapaTeclas[teclaPressionada];
 
   if (ferramentaAlvo) {
     e.preventDefault();
@@ -676,6 +658,8 @@ window.addEventListener("keydown", (e) => {
     }
   }
 });
+
+
 
 // --- Área de Transferência (Copiar / Colar) ---
 let clipboard = [];       

--- a/js/main.js
+++ b/js/main.js
@@ -504,9 +504,11 @@ window.addEventListener("keydown", (e) => {
   if (["input", "textarea", "select"].includes(tagAtiva) || elementoAtivo.isContentEditable)
     return;
 
-  // Atalhos de teclado para o histórico
+  // 1. Agrupamos TODA lógica que depende obrigatoriamente de Ctrl / Cmd
   if (e.ctrlKey || e.metaKey) {
-    if (e.key.toLowerCase() === 'g') {
+    const teclaCtrl = e.key.toLowerCase();
+
+    if (teclaCtrl === 'g') {
       e.preventDefault();
       if (e.shiftKey) {
         desagruparElementos();
@@ -516,7 +518,7 @@ window.addEventListener("keydown", (e) => {
       atualizarBotoesHistorico();
       return;
     }
-    if (e.key.toLowerCase() === 'z') {
+    if (teclaCtrl === 'z') {
       e.preventDefault();
       if (e.shiftKey) {
         refazerAcao();
@@ -526,30 +528,20 @@ window.addEventListener("keydown", (e) => {
       atualizarBotoesHistorico();
       return;
     }
-    if (e.key.toLowerCase() === 'y') {
+    if (teclaCtrl === 'y') {
       e.preventDefault();
       refazerAcao();
       atualizarBotoesHistorico();
       return;
     }
-    // Ctrl+C / Ctrl+V / Ctrl+D são tratados em outro listener — apenas impede
-    // que caiam no mapa de atalhos de ferramenta abaixo.
-    if (['c', 'v', 'd'].includes(e.key.toLowerCase())) {
+    
+    // Agora este bloqueio está protegido dentro do bloco "if (e.ctrlKey || e.metaKey)"
+    // Ele impede que Ctrl+C, Ctrl+V ou Ctrl+D vazem para o mapa de ferramentas abaixo,
+    // mas não interfere quando as teclas C, V ou D são pressionadas sozinhas!
+    if (['c', 'v', 'd'].includes(teclaCtrl)) {
       return;
     }
   }
-
-  const mapaTeclas = {
-    "s" : "selecao",
-    "r" : "retangulo",
-    "e" : "elipse",
-    "l" : "linha",
-    "c" : "linhaCurvada",
-    "p" : "poligono",
-    "t" : "texto",
-    "i" : "Conta-gotas",
-    "g" : "losango",
-  };
 
   // --- LÓGICA DE DELEÇÃO CORRIGIDA ---
   if (e.key === "Delete" || e.key === "Backspace") {
@@ -562,6 +554,19 @@ window.addEventListener("keydown", (e) => {
     }
     return;
   }
+
+  // 2. Se chegou aqui e Ctrl/Cmd NÃO está ativo, as teclas isoladas seguem normalmente para as ferramentas
+  const mapaTeclas = {
+    "s" : "selecao",
+    "r" : "retangulo",
+    "e" : "elipse",
+    "l" : "linha",
+    "c" : "linhaCurvada", // Agora funciona livremente ao digitar "C" sozinho!
+    "p" : "poligono",
+    "t" : "texto",
+    "i" : "Conta-gotas",
+    "g" : "losango",
+  };
 
   const teclaPressionada = e.key.toLowerCase();
   const ferramentaAlvo = e.shiftKey && teclaPressionada === 'c'

--- a/js/main.js
+++ b/js/main.js
@@ -19,40 +19,55 @@ import {
   desfazerAcao,
   refazerAcao,
   registrarAcaoHistorico,
-  atualizarPosicaoSelecaoVisual
-} from './core/StateManager.js';
-import { ColorPickerTool } from './tools/ColorPickerTool.js';
-import { Lapis } from './tools/LapisTool.js';
-import { RetanguloTool } from './tools/RetanguloTool.js';
-import { TextoTool } from './tools/TextoTool.js';
-import { exportarDesenho } from './utils/exportHelpers.js';
-import { SelecaoTool } from './tools/SelecaoTool.js';
-import { Selecao } from './core/Selecao.js';
-import { BorrachaTool } from './tools/BorrachaTool.js';
-import { NodeEditTool } from './tools/NodeEditTool.js';
-import { LinhaTool } from './tools/LinhaTool.js';
-import { LinhaCurvadaTool } from './tools/LinhaCurvadaTool.js';
-import { BezierTool } from './tools/BezierTool.js';
-import { ElipseTool } from './tools/ElipseTool.js';
-import { EspiralTool } from './tools/EspiralTool.js';
-import { LupaTool } from './tools/LupaTool.js';
-import { inicializarImportadorImagem } from './tools/ImageImporter.js';
-import { inicializarMenuInicial } from './core/UIManager.js';
-import { duplicarElemento } from './utils/duplicateHelpers.js';
-import { PoligonoPolilinhaTool } from './tools/PoligonoPolilinhaTool.js';
-import { SideBar } from './core/SideBar.js';
-import { PincelTool } from './tools/PincelTool.js';
-import {definirEspessuraLapis} from "./core/StateManager.js";
-import { CameraSVG } from './core/CameraSVG.js';
-import { ScrollbarSVG } from './core/ScrollbarSVG.js';
-import { obterCoordenadaSVG } from './utils/svgHelpers.js';
-import { HistoryManager } from './core/HistoryManager.js';
-import { Regua } from './core/Regua.js';
-import { LosangoTool } from './tools/LosangoTool.js';
-import { agruparElementos, desagruparElementos } from './core/GroupManager.js';
+  definirCallbackPainelAlinhamento,
+  atualizarPosicaoSelecaoVisual,
+  definirEspessuraLapis,
+} from "./core/StateManager.js";
+import { ColorPickerTool } from "./tools/ColorPickerTool.js";
+import { Lapis } from "./tools/LapisTool.js";
+import { RetanguloTool } from "./tools/RetanguloTool.js";
+import { TextoTool } from "./tools/TextoTool.js";
+import { exportarDesenho } from "./utils/exportHelpers.js";
+import { SelecaoTool } from "./tools/SelecaoTool.js";
+import { Selecao } from "./core/Selecao.js";
+import { BorrachaTool } from "./tools/BorrachaTool.js";
+import { NodeEditTool } from "./tools/NodeEditTool.js";
+import { LinhaTool } from "./tools/LinhaTool.js";
+import { LinhaCurvadaTool } from "./tools/LinhaCurvadaTool.js";
+import { BezierTool } from "./tools/BezierTool.js";
+import { ElipseTool } from "./tools/ElipseTool.js";
+import { EspiralTool } from "./tools/EspiralTool.js";
+import { LupaTool } from "./tools/LupaTool.js";
+import { inicializarImportadorImagem } from "./tools/ImageImporter.js";
+import { inicializarMenuInicial } from "./core/UIManager.js";
+import { duplicarElemento } from "./utils/duplicateHelpers.js";
+import { PoligonoPolilinhaTool } from "./tools/PoligonoPolilinhaTool.js";
+import { inicializarMenuContexto } from "./contextMenu/index.js";
+import { SideBar } from "./core/SideBar.js";
+import { PincelTool } from "./tools/PincelTool.js";
+import { CameraSVG } from "./core/CameraSVG.js";
+import { ScrollbarSVG } from "./core/ScrollbarSVG.js";
+import { obterCoordenadaSVG } from "./utils/svgHelpers.js";
+import { HistoryManager } from "./core/HistoryManager.js";
+import { Regua } from "./core/Regua.js";
+import { LosangoTool } from "./tools/LosangoTool.js";
+import { agruparElementos, desagruparElementos } from "./core/GroupManager.js";
 import { espelharHorizontal, espelharVertical } from "./utils/flipHelpers.js";
+import {
+  alinharEsquerda,
+  alinharCentroHorizontal,
+  alinharDireita,
+  alinharTopo,
+  alinharCentroVertical,
+  alinharBase,
+  distribuirHorizontalmente,
+  distribuirVerticalmente,
+} from "./utils/alignHelpers.js";
+import { salvarRascunho, marcarSalvo } from "./utils/autoSave.js";
+import { ImageTracerManager } from "./tools/ImageTracerManager.js";
+import { MedidorTool } from "./tools/MedidorTool.js";
 
-const svgCanvas = document.getElementById('canvas');
+const svgCanvas = document.getElementById("canvas");
 
 // Instancia HistoryManager
 const historyManager = new HistoryManager(svgCanvas);
@@ -64,92 +79,108 @@ inicializarMenuInicial(svgCanvas);
 // Inicializar a sidebar
 const barraLateral = new SideBar();
 
-const areaDesenho = document.getElementById('area-desenho');
-const botoesFerramenta = document.querySelectorAll('.btn-ferramenta');
-const btnImportarImagem = document.getElementById('btn-importar-imagem');
-const inputImagem = document.getElementById('input-imagem');
-const inputCorPreenchimento = document.getElementById('cor-preenchimento');
-const inputCorBorda = document.getElementById('cor-borda');
-const botoesEstiloLinha = document.querySelectorAll('.btn-line-style');
-const nomeFerramenta = document.getElementById('nome-ferramenta');
-const btnExportar = document.getElementById('btn-exportar');
-const exportFormat = document.getElementById('export-format');
-const inputEspessuraLapis =  document.getElementById("espessura-lapis");
+const areaDesenho = document.getElementById("area-desenho");
+const botoesFerramenta = document.querySelectorAll(".btn-ferramenta");
+const btnImportarImagem = document.getElementById("btn-importar-imagem");
+const inputImagem = document.getElementById("input-imagem");
+const inputCorPreenchimento = document.getElementById("cor-preenchimento");
+const inputCorBorda = document.getElementById("cor-borda");
+const botoesEstiloLinha = document.querySelectorAll(".btn-line-style");
+const nomeFerramenta = document.getElementById("nome-ferramenta");
+const btnExportar = document.getElementById("btn-exportar");
+const exportFormat = document.getElementById("export-format");
+const inputEspessuraLapis = document.getElementById("espessura-lapis");
+
+const indicadorNaoSalvo = document.getElementById("indicador-nao-salvo");
+function mostrarIndicadorNaoSalvo() {
+  if (indicadorNaoSalvo) indicadorNaoSalvo.classList.remove("oculto");
+}
+function ocultarIndicadorNaoSalvo() {
+  if (indicadorNaoSalvo) indicadorNaoSalvo.classList.add("oculto");
+}
 
 // Botões de histórico
-const btnDesfazer = document.getElementById('btn-desfazer');
-const btnRefazer = document.getElementById('btn-refazer');
+const btnDesfazer = document.getElementById("btn-desfazer");
+const btnRefazer = document.getElementById("btn-refazer");
 
 // Função para atualizar o estado dos botões de histórico
 function atualizarBotoesHistorico() {
-    if (!historyManager) return;
+  if (!historyManager) return;
 
-    const podeDesfazer = historyManager.podeDesfazer();
-    const podeRefazer = historyManager.podeRefazer();
+  const podeDesfazer = historyManager.podeDesfazer();
+  const podeRefazer = historyManager.podeRefazer();
 
-    if (btnDesfazer) {
-        btnDesfazer.disabled = !podeDesfazer;
-        btnDesfazer.title = podeDesfazer ? 'Desfazer (Ctrl+Z)' : 'Nada para desfazer';
-    }
+  if (btnDesfazer) {
+    btnDesfazer.disabled = !podeDesfazer;
+    btnDesfazer.title = podeDesfazer
+      ? "Desfazer (Ctrl+Z)"
+      : "Nada para desfazer";
+  }
 
-    if (btnRefazer) {
-        btnRefazer.disabled = !podeRefazer;
-        btnRefazer.title = podeRefazer ? 'Refazer (Ctrl+Y)' : 'Nada para refazer';
-    }
+  if (btnRefazer) {
+    btnRefazer.disabled = !podeRefazer;
+    btnRefazer.title = podeRefazer
+      ? "Refazer (Ctrl+Y / Ctrl+Shift+Z)"
+      : "Nada para refazer";
+  }
 }
 
 // Sobrescrever o método salvarEstado do historyManager para atualizar os botões
 const salvarEstadoOriginal = historyManager.salvarEstado.bind(historyManager);
-historyManager.salvarEstado = function() {
-    const resultado = salvarEstadoOriginal();
-    atualizarBotoesHistorico();
-    return resultado;
+historyManager.salvarEstado = function () {
+  const resultado = salvarEstadoOriginal();
+  atualizarBotoesHistorico();
+  return resultado;
 };
 
 const desfazerOriginal = historyManager.desfazer.bind(historyManager);
-historyManager.desfazer = function() {
-    const resultado = desfazerOriginal();
-    atualizarBotoesHistorico();
-    return resultado;
+historyManager.desfazer = function () {
+  const resultado = desfazerOriginal();
+  atualizarBotoesHistorico();
+  return resultado;
 };
 
 const refazerOriginal = historyManager.refazer.bind(historyManager);
-historyManager.refazer = function() {
-    const resultado = refazerOriginal();
-    atualizarBotoesHistorico();
-    return resultado;
+historyManager.refazer = function () {
+  const resultado = refazerOriginal();
+  atualizarBotoesHistorico();
+  return resultado;
 };
 
 // Configurar event listeners dos botões de histórico
 if (btnDesfazer) {
-    btnDesfazer.addEventListener('click', () => {
-        desfazerAcao();
-        atualizarBotoesHistorico();
-    });
+  btnDesfazer.addEventListener("click", () => {
+    desfazerAcao();
+    atualizarBotoesHistorico();
+  });
 }
 
 if (btnRefazer) {
-    btnRefazer.addEventListener('click', () => {
-        refazerAcao();
-        atualizarBotoesHistorico();
-    });
+  btnRefazer.addEventListener("click", () => {
+    refazerAcao();
+    atualizarBotoesHistorico();
+  });
 }
 
 // Novos botões de "Nenhum"
-const btnPreenchimentoNenhum = document.getElementById('btn-preenchimento-nenhum');
-const btnBordaNenhum = document.getElementById('btn-borda-nenhum');
+const btnPreenchimentoNenhum = document.getElementById(
+  "btn-preenchimento-nenhum",
+);
+const btnBordaNenhum = document.getElementById("btn-borda-nenhum");
 
 // Novos Sliders de opacidade
-const sliderOpacidadePreenchimento = document.getElementById('opacity-preenchimento');
-const sliderOpacidadeBorda = document.getElementById('opacity-borda');
+const sliderOpacidadePreenchimento = document.getElementById(
+  "opacity-preenchimento",
+);
+const sliderOpacidadeBorda = document.getElementById("opacity-borda");
 
 // Wrapper para sincronizar perfeitamente as coordenadas do #canvas com o #overlay-canvas
-const canvasContainer = document.createElement('div');
-canvasContainer.style.position = 'relative';
-canvasContainer.style.width = '100%';
-canvasContainer.style.height = '100%';
-canvasContainer.style.paddingTop = '20px';
-canvasContainer.style.paddingLeft = '20px';
+const canvasContainer = document.createElement("div");
+canvasContainer.style.position = "relative";
+canvasContainer.style.width = "100%";
+canvasContainer.style.height = "100%";
+canvasContainer.style.paddingTop = "20px";
+canvasContainer.style.paddingLeft = "20px";
 
 // Encapsulando o svg original
 svgCanvas.parentNode.insertBefore(canvasContainer, svgCanvas);
@@ -168,28 +199,28 @@ canvasContainer.appendChild(overlayCanvas);
 
 // Réguas de medida (em pixels) nas bordas do canvas
 const regua = new Regua(canvasContainer, svgCanvas);
-const btnToggleRegua = document.getElementById('btn-toggle-regua');
+const btnToggleRegua = document.getElementById("btn-toggle-regua");
 if (btnToggleRegua) {
-  btnToggleRegua.addEventListener('click', () => {
+  btnToggleRegua.addEventListener("click", () => {
     const ativa = regua.alternar();
-    btnToggleRegua.classList.toggle('ativo', ativa);
+    btnToggleRegua.classList.toggle("ativo", ativa);
   });
 }
 
 // Sincronizar viewBox entre canvas principal e overlay quando necessário
 const observer = new MutationObserver((mutations) => {
   mutations.forEach((mutation) => {
-    if (mutation.attributeName === 'viewBox') {
-      const vb = svgCanvas.getAttribute('viewBox');
+    if (mutation.attributeName === "viewBox") {
+      const vb = svgCanvas.getAttribute("viewBox");
       if (vb) {
-        overlayCanvas.setAttribute('viewBox', vb);
+        overlayCanvas.setAttribute("viewBox", vb);
       } else {
-        overlayCanvas.removeAttribute('viewBox');
+        overlayCanvas.removeAttribute("viewBox");
       }
     }
   });
 });
-observer.observe(svgCanvas, { attributes: true, attributeFilter: ['viewBox'] });
+observer.observe(svgCanvas, { attributes: true, attributeFilter: ["viewBox"] });
 
 // Inicializar a classe de seleção visual
 const selecaoVisual = new Selecao(overlayCanvas);
@@ -215,6 +246,7 @@ const instanciasFerramentas = {
   lapis: new Lapis(svgCanvas),
   losango: new LosangoTool(svgCanvas),
   pincel: new PincelTool(svgCanvas),
+  medidor: new MedidorTool(svgCanvas, cameraGlobal),
 };
 
 /**
@@ -226,28 +258,28 @@ const instanciasFerramentas = {
 function atualizarBotaoAtivo(nomeDaFerramenta) {
   let btnAtivo = null;
   botoesFerramenta.forEach((btn) => {
-    if (btn.getAttribute('data-ferramenta') === nomeDaFerramenta) {
-      btn.classList.add('ativo');
+    if (btn.getAttribute("data-ferramenta") === nomeDaFerramenta) {
+      btn.classList.add("ativo");
       btnAtivo = btn;
     } else {
-      btn.classList.remove('ativo');
+      btn.classList.remove("ativo");
     }
   });
-  nomeFerramenta.textContent = btnAtivo?.dataset.nome || 'Nenhuma';
+  nomeFerramenta.textContent = btnAtivo?.dataset.nome || "Nenhuma";
 }
 
 // --- Barra de Ferramentas & Modos ---
 botoesFerramenta.forEach((btn) => {
-  btn.addEventListener('click', () => {
-    const ferramentaId = btn.getAttribute('data-ferramenta');
+  btn.addEventListener("click", () => {
+    const ferramentaId = btn.getAttribute("data-ferramenta");
     if (!ferramentaId) return;
 
     const ferramentaInstancia = instanciasFerramentas[ferramentaId] || null;
 
     if (
-      ferramentaId === 'linha' &&
+      ferramentaId === "linha" &&
       estado.ferramentaAtual === ferramentaInstancia &&
-      typeof ferramentaInstancia.openPanel === 'function'
+      typeof ferramentaInstancia.openPanel === "function"
     ) {
       ferramentaInstancia.openPanel();
       return;
@@ -259,33 +291,33 @@ botoesFerramenta.forEach((btn) => {
 });
 
 // Ouvir mudanças no input de cor de preenchimento da sidebar
-inputCorPreenchimento.addEventListener('input', () => {
+inputCorPreenchimento.addEventListener("input", () => {
   const novaCor = inputCorPreenchimento.value;
   definirCorPreenchimento(novaCor);
   // Preenche cada elemento selecionado com a cor desejada
-  estado.elementosSelecionados.forEach(el => {
-    el.setAttribute('fill', novaCor);
+  estado.elementosSelecionados.forEach((el) => {
+    el.setAttribute("fill", novaCor);
   });
 });
 
 // Ouvir mudanças no input de cor de borda da sidebar
-inputCorBorda.addEventListener('input', () => {
+inputCorBorda.addEventListener("input", () => {
   const novaCor = inputCorBorda.value;
   definirCorBorda(novaCor);
   // Colore a borda de cada elemento selecionado com a cor desejada
-  estado.elementosSelecionados.forEach(el => {
-    el.setAttribute('stroke', novaCor);
+  estado.elementosSelecionados.forEach((el) => {
+    el.setAttribute("stroke", novaCor);
   });
 });
 
 function atualizarBotaoEstiloLinhaAtivo(estiloLinha) {
   botoesEstiloLinha.forEach((btn) => {
-    btn.classList.toggle('ativo', btn.dataset.estiloLinha === estiloLinha);
+    btn.classList.toggle("ativo", btn.dataset.estiloLinha === estiloLinha);
   });
 }
 
 botoesEstiloLinha.forEach((btn) => {
-  btn.addEventListener('click', () => {
+  btn.addEventListener("click", () => {
     const estiloLinha = btn.dataset.estiloLinha;
     definirEstiloLinha(estiloLinha);
     atualizarBotaoEstiloLinhaAtivo(estiloLinha);
@@ -294,7 +326,7 @@ botoesEstiloLinha.forEach((btn) => {
 
 // Atualizar os inputs da sidebar quando o usuário selecionar um objeto
 // Usamos um MutationObserver ou interceptamos cliques no Canvas para capturar a seleção.
-svgCanvas.addEventListener('mouseup', (evento) => {
+svgCanvas.addEventListener("mouseup", (evento) => {
   if (estado.ferramentaAtual) {
     estado.ferramentaAtual.onMouseUp(evento);
   }
@@ -309,10 +341,13 @@ svgCanvas.addEventListener('mouseup', (evento) => {
     const opacidadeBordaAtual = primeiroSelecionado.getAttribute('stroke-opacity') || '1';
 
     // Só atualizamos os seletores visuais do HTML se o valor do SVG for uma cor hexadecimal válida.
-    if (corPreenchimentoAtual !== 'none' && corPreenchimentoAtual.startsWith('#')) {
+    if (
+      corPreenchimentoAtual !== "none" &&
+      corPreenchimentoAtual.startsWith("#")
+    ) {
       inputCorPreenchimento.value = corPreenchimentoAtual;
     }
-    if (corBordaAtual !== 'none' && corBordaAtual.startsWith('#')) {
+    if (corBordaAtual !== "none" && corBordaAtual.startsWith("#")) {
       inputCorBorda.value = corBordaAtual;
     }
 
@@ -324,6 +359,10 @@ svgCanvas.addEventListener('mouseup', (evento) => {
     definirCorPreenchimento(corPreenchimentoAtual);
     definirCorBorda(corBordaAtual);
   }
+
+  // Auto-save silencioso após cada ação de desenho concluída no canvas principal
+  salvarRascunho(svgCanvas, estado, "editor");
+  mostrarIndicadorNaoSalvo();
 });
 
 btnPreenchimentoNenhum.addEventListener('click', () => {
@@ -348,7 +387,7 @@ btnBordaNenhum.addEventListener('click', () => {
   atualizarBotoesHistorico();
 });
 
-sliderOpacidadePreenchimento.addEventListener('input', () => {
+sliderOpacidadePreenchimento.addEventListener("input", () => {
   const valor = sliderOpacidadePreenchimento.value;
   
   estado.elementosSelecionados.forEach(el => {
@@ -362,7 +401,7 @@ sliderOpacidadePreenchimento.addEventListener('change', () => {
   atualizarBotoesHistorico();
 });
 
-sliderOpacidadeBorda.addEventListener('input', () => {
+sliderOpacidadeBorda.addEventListener("input", () => {
   const valor = sliderOpacidadeBorda.value;
   
   estado.elementosSelecionados.forEach(el => {
@@ -370,19 +409,19 @@ sliderOpacidadeBorda.addEventListener('input', () => {
   });
 });
 
-sliderOpacidadeBorda.addEventListener('change', () => {
+sliderOpacidadeBorda.addEventListener("change", () => {
   registrarAcaoHistorico();
   atualizarBotoesHistorico();
 });
 
 // Event listeners globais do SVG (delegados para a ferramenta ativa)
-svgCanvas.addEventListener('mousedown', (evento) => {
+svgCanvas.addEventListener("mousedown", (evento) => {
   if (estado.ferramentaAtual) {
     estado.ferramentaAtual.onMouseDown(evento);
   }
 });
 
-svgCanvas.addEventListener('mousemove', (evento) => {
+svgCanvas.addEventListener("mousemove", (evento) => {
   if (estado.ferramentaAtual) {
     estado.ferramentaAtual.onMouseMove(evento);
   }
@@ -391,27 +430,30 @@ svgCanvas.addEventListener('mousemove', (evento) => {
 // O overlay tem pointer-events:none (para não bloquear cliques no canvas),
 // exceto nos elementos de UI que o próprio Selecao habilita explicitamente
 // (ex: alças de skew) — por isso precisa dos mesmos listeners delegados.
-overlayCanvas.addEventListener('mousedown', (evento) => {
+overlayCanvas.addEventListener("mousedown", (evento) => {
   if (estado.ferramentaAtual) {
     estado.ferramentaAtual.onMouseDown(evento);
   }
 });
 
-overlayCanvas.addEventListener('mousemove', (evento) => {
+overlayCanvas.addEventListener("mousemove", (evento) => {
   if (estado.ferramentaAtual) {
     estado.ferramentaAtual.onMouseMove(evento);
   }
 });
 
-overlayCanvas.addEventListener('mouseup', (evento) => {
+overlayCanvas.addEventListener("mouseup", (evento) => {
   if (estado.ferramentaAtual) {
     estado.ferramentaAtual.onMouseUp(evento);
   }
+  // Auto-save silencioso após ações realizadas via overlay (ex: mover seleções, lápis)
+  salvarRascunho(svgCanvas, estado, "editor");
+  mostrarIndicadorNaoSalvo();
 });
 
 // Previne o menu de opções do botão direito no canvas
-svgCanvas.addEventListener('contextmenu', (e) => {
-  if (e.target.closest('#canvas')) {
+svgCanvas.addEventListener("contextmenu", (e) => {
+  if (e.target.closest("#canvas")) {
     e.preventDefault();
   }
 });
@@ -422,8 +464,8 @@ inputCorBorda.value = estado.corBorda;
 atualizarBotaoEstiloLinhaAtivo(estado.estiloLinha);
 
 // Exportar / Salvar desenho
-btnExportar.addEventListener('click', () => {
-  const formato = exportFormat.value || 'png';
+btnExportar.addEventListener("click", () => {
+  const formato = exportFormat.value || "png";
   exportarDesenho(svgCanvas, formato);
 });
 
@@ -436,10 +478,10 @@ inputEspessuraLapis.addEventListener("input", (e) => {
 });
 
 // --- Controle de Camadas (Z-Index) ---
-const btnSendToBack = document.getElementById('btn-send-to-back');
-const btnStepBackward = document.getElementById('btn-step-backward');
-const btnStepForward = document.getElementById('btn-step-forward');
-const btnBringToFront = document.getElementById('btn-bring-to-front');
+const btnSendToBack = document.getElementById("btn-send-to-back");
+const btnStepBackward = document.getElementById("btn-step-backward");
+const btnStepForward = document.getElementById("btn-step-forward");
+const btnBringToFront = document.getElementById("btn-bring-to-front");
 
 function moverCamada(acao) {
   const elementos = estado.elementosSelecionados;
@@ -453,20 +495,20 @@ function moverCamada(acao) {
   if (!pai) return;
 
   switch (acao) {
-    case 'fundo':
+    case "fundo":
       pai.prepend(el);
       break;
-    case 'recuar':
+    case "recuar":
       if (el.previousElementSibling) {
         el.previousElementSibling.before(el);
       }
       break;
-    case 'avancar':
+    case "avancar":
       if (el.nextElementSibling) {
         el.nextElementSibling.after(el);
       }
       break;
-    case 'frente':
+    case "frente":
       pai.appendChild(el);
       break;
   }
@@ -475,35 +517,29 @@ function moverCamada(acao) {
   atualizarBotoesHistorico();
 }
 
-btnSendToBack.addEventListener('click', () => moverCamada('fundo'));
-btnStepBackward.addEventListener('click', () => moverCamada('recuar'));
-btnStepForward.addEventListener('click', () => moverCamada('avancar'));
-btnBringToFront.addEventListener('click', () => moverCamada('frente'));
+btnSendToBack.addEventListener("click", () => moverCamada("fundo"));
+btnStepBackward.addEventListener("click", () => moverCamada("recuar"));
+btnStepForward.addEventListener("click", () => moverCamada("avancar"));
+btnBringToFront.addEventListener("click", () => moverCamada("frente"));
 
 // --- Configurar Espelhamento ---
-const btnFlipHorizontal = document.getElementById('btn-flip-horizontal');
-const btnFlipVertical = document.getElementById('btn-flip-vertical');
+const btnFlipHorizontal = document.getElementById("btn-flip-horizontal");
+const btnFlipVertical = document.getElementById("btn-flip-vertical");
 
 btnFlipHorizontal.addEventListener("click", () => {
-
-    estado.elementosSelecionados.forEach(el => {
-        espelharHorizontal(el);
-    });
-
-    atualizarPosicaoSelecaoVisual();
-    registrarAcaoHistorico();
-
+  estado.elementosSelecionados.forEach((el) => {
+    espelharHorizontal(el);
+  });
+  atualizarPosicaoSelecaoVisual();
+  registrarAcaoHistorico();
 });
 
 btnFlipVertical.addEventListener("click", () => {
-
-    estado.elementosSelecionados.forEach(el => {
-        espelharVertical(el);
-    });
-
-    atualizarPosicaoSelecaoVisual();
-    registrarAcaoHistorico();
-
+  estado.elementosSelecionados.forEach((el) => {
+    espelharVertical(el);
+  });
+  atualizarPosicaoSelecaoVisual();
+  registrarAcaoHistorico();
 });
 
 // Atalhos de Teclado (Tool Selection)
@@ -514,12 +550,15 @@ window.addEventListener("keydown", (e) => {
   const tagAtiva = elementoAtivo.tagName.toLocaleLowerCase();
 
   // Se o foco estiver em um input, textArea, select ou contentEditable, ignora o atalho.
-  if (["input", "textarea", "select"].includes(tagAtiva) || elementoAtivo.isContentEditable)
+  if (
+    ["input", "textarea", "select"].includes(tagAtiva) ||
+    elementoAtivo.isContentEditable
+  )
     return;
 
   // Atalhos de teclado para o histórico
   if (e.ctrlKey || e.metaKey) { // metaKey é o Cmd do Mac
-    if (e.key.toLowerCase() === 'g') {
+    if (e.key.toLowerCase() === "g") {
       e.preventDefault(); // Impede o navegador de tentar buscar (find)
       if (e.shiftKey) {
         desagruparElementos();
@@ -529,7 +568,7 @@ window.addEventListener("keydown", (e) => {
       atualizarBotoesHistorico(); // Sincroniza a interface de histórico
       return;
     }
-    if (e.key.toLowerCase() === 'z') {
+    if (e.key.toLowerCase() === "z") {
       e.preventDefault();
       if (e.shiftKey) {
         refazerAcao();
@@ -539,10 +578,20 @@ window.addEventListener("keydown", (e) => {
       atualizarBotoesHistorico();
       return;
     }
-    if (e.key.toLowerCase() === 'y') {
+    if (e.key.toLowerCase() === "y") {
       e.preventDefault();
       refazerAcao();
       atualizarBotoesHistorico();
+      return;
+    }
+    if (e.key === "]" || e.key === "}") {
+      e.preventDefault();
+      moverCamada(e.shiftKey ? "frente" : "avancar");
+      return;
+    }
+    if (e.key === "[" || e.key === "{") {
+      e.preventDefault();
+      moverCamada(e.shiftKey ? "fundo" : "recuar");
       return;
     }
     // Ctrl+C / Ctrl+V / Ctrl+D são tratados em outro listener — apenas impede
@@ -552,28 +601,93 @@ window.addEventListener("keydown", (e) => {
     }
   }
 
-  const mapaTeclas = {
-    "s" : "selecao",
-    "r" : "retangulo",
-    "e" : "elipse",
-    "l" : "linha",
-    "c" : "linhaCurvada",
-    "p" : "poligono",
-    "t" : "texto",
-    "i" : "Conta-gotas",
-    "g": "losango",
+  const teclaPressionada = e.key.toLowerCase();
+
+  // Atalhos com Shift
+  if (e.shiftKey) {
+    const mapaTeclasShift = {
+      c: "bezier",
+      e: "espiral",
+    };
+
+    if (teclaPressionada === "z") {
+      e.preventDefault();
+      const btnDrag = document.getElementById("btn-drag");
+      if (btnDrag) {
+        btnDrag.click();
+      } else {
+        const botaoZoom = document.querySelector(
+          '.btn-ferramenta[data-ferramenta="lupa"]',
+        );
+        if (botaoZoom) {
+          botaoZoom.click();
+          setTimeout(() => document.getElementById("btn-drag")?.click(), 0);
+        }
+      }
+    } else if (teclaPressionada === "i") {
+      e.preventDefault();
+      btnImportarImagem?.click();
+    } else if (teclaPressionada === "h") {
+      e.preventDefault();
+      btnFlipHorizontal?.click();
+    } else if (teclaPressionada === "v") {
+      e.preventDefault();
+      btnFlipVertical?.click();
+    } else if (teclaPressionada === "r") {
+      e.preventDefault();
+      btnToggleRegua?.click();
+    } else if (mapaTeclasShift[teclaPressionada]) {
+      e.preventDefault();
+      const botao = document.querySelector(
+        `.btn-ferramenta[data-ferramenta="${mapaTeclasShift[teclaPressionada]}"]`,
+      );
+      if (botao) {
+        botao.click();
+      }
+    }
+    return;
   }
 
-  const teclaPressionada = e.key.toLowerCase();
-  const ferramentaAlvo = e.shiftKey && teclaPressionada === 'c'
-    ? 'bezier'
-    : e.shiftKey && teclaPressionada === 'e'
-      ? 'espiral'
-    : mapaTeclas[teclaPressionada];
+  const mapaTeclas = {
+    s: "selecao",
+    r: "retangulo",
+    e: "elipse",
+    l: "linha",
+    c: "linhaCurvada",
+    g: "poligono",
+    p: "lapis",
+    t: "texto",
+    i: "Conta-gotas",
+    b: "borracha",
+    v: "edicaoVertices",
+    z: "lupa",
+    d: "pincel",
+    h: "losango",
+    m: "medidor",
+  };
+
+  // --- LÓGICA DE DELEÇÃO ---
+  if (e.key === "Delete" || e.key === "Backspace") {
+    if (
+      estado.elementosSelecionados &&
+      estado.elementosSelecionados.length > 0
+    ) {
+      estado.elementosSelecionados.forEach((el) => el.remove());
+      definirElementosSelecionados([]);
+      atualizarPosicaoSelecaoVisual();
+      registrarAcaoHistorico();
+      atualizarBotoesHistorico();
+    }
+    return;
+  }
+
+  const ferramentaAlvo = mapaTeclas[teclaPressionada];
 
   if (ferramentaAlvo) {
     e.preventDefault();
-    const botao = document.querySelector(`.btn-ferramenta[data-ferramenta="${ferramentaAlvo}"]`);
+    const botao = document.querySelector(
+      `.btn-ferramenta[data-ferramenta="${ferramentaAlvo}"]`,
+    );
     if (botao) {
       botao.click();
     }
@@ -642,25 +756,42 @@ document.addEventListener('keydown', (evento) => {
 });
 
 // Importação de imagens
-btnImportarImagem.addEventListener('click', () => {
+btnImportarImagem.addEventListener("click", () => {
   inputImagem.click();
 });
 
 inicializarImportadorImagem(svgCanvas, inputImagem);
 
+// --- Inicialização do ImageTracer ---
+const tracerManager = new ImageTracerManager(svgCanvas, inputImagem);
+// Assiste a aba do Tracer para atualizar a lista de imagens quando ela for ativada
+const tabTracer = document.getElementById("tab-tracer");
+if (tabTracer) {
+    const observerTab = new MutationObserver(() => {
+      // Verifica se a classe 'ativo' foi adicionada pela SideBar.js
+        if (tabTracer.classList.contains('ativo')) {
+            tracerManager.atualizarLista();
+        }
+    });
+    observerTab.observe(tabTracer, { attributes: true, attributeFilter: ['class'] });
+}
+
 // Inicializar o estado dos botões de histórico
 atualizarBotoesHistorico();
 
 // Ctrl + Scroll — Zoom global (funciona com qualquer ferramenta ativa)
-svgCanvas.addEventListener('wheel', (e) => {
-  if (!e.ctrlKey) return;
-  e.preventDefault();
+svgCanvas.addEventListener(
+  "wheel",
+  (e) => {
+    if (!e.ctrlKey) return;
+    e.preventDefault();
 
-  const coords = obterCoordenadaSVG(e, svgCanvas);
-  const fator = 0.1;
-  const escala = e.deltaY > 0
-    ? 1 + fator   // scroll para baixo = zoom out
-    : 1 - fator;  // scroll para cima  = zoom in
+    const coords = obterCoordenadaSVG(e, svgCanvas);
+    const fator = 0.1;
+    const escala =
+      e.deltaY > 0
+        ? 1 + fator // scroll para baixo = zoom out
+        : 1 - fator; // scroll para cima  = zoom in
 
   cameraGlobal.zoom(escala, coords.x, coords.y);
   scrollbar.atualizar();

--- a/js/utils/duplicateHelpers.js
+++ b/js/utils/duplicateHelpers.js
@@ -1,20 +1,10 @@
-import { criarElementoSVG } from './svgHelpers.js';
-
-const OFFSET_DEFAULT = 20;
-
-const TAG_POS_ATTRS = {
-  rect: { x: 'x', y: 'y' },
-  image: { x: 'x', y: 'y' },
-  text: { x: 'x', y: 'y' },
-  circle: { x: 'cx', y: 'cy' },
-  ellipse: { x: 'cx', y: 'cy' },
-  line: { x: ['x1', 'x2'], y: ['y1', 'y2'] }
-};
-
 function ajustarPosicaoElemento(elemento, offsetX, offsetY) {
   const tag = elemento.tagName ? elemento.tagName.toLowerCase() : '';
 
-  if (tag === 'g') {
+  // Agrupamos as tags que devem ser deslocadas via transform/translate
+  const tagsComTransform = ['g', 'path', 'polygon', 'polyline'];
+
+  if (tagsComTransform.includes(tag)) {
     const transformAttr = elemento.getAttribute('transform') || '';
     let translateX = 0;
     let translateY = 0;
@@ -55,22 +45,4 @@ function ajustarPosicaoElemento(elemento, offsetX, offsetY) {
     const yVal = parseFloat(elemento.getAttribute(attrs.y)) || 0;
     elemento.setAttribute(attrs.y, yVal + offsetY);
   }
-}
-
-function clonarRecursivamente(elemento, offsetX, offsetY) {
-  const clone = elemento.cloneNode(true);
-  ajustarPosicaoElemento(clone, offsetX, offsetY);
-  return clone;
-}
-
-export function duplicarElemento(elemento, svgCanvas, offsetX = OFFSET_DEFAULT, offsetY = OFFSET_DEFAULT) {
-  if (!elemento || !svgCanvas) {
-    console.warn('duplicarElemento: elemento ou svgCanvas inválido');
-    return null;
-  }
-
-  const clone = clonarRecursivamente(elemento, offsetX, offsetY);
-  svgCanvas.appendChild(clone);
-
-  return clone;
 }


### PR DESCRIPTION
Adicionei a funcionalidade de copiar e colar utilizando atalhos tradicionais de teclado.
Control + c $\rightarrow$ copia objeto selecionado.
Control + v $\rightarrow$ cola objeto selecionado com um deslocamento de $10 pixels$ para não sobrepor objeto original.

Aguardando revisão para mergear.

@Julio-C-Oliveira 
@RafaelDmiranda 
@Savio-Miranda 


