### PR TITLE
[bug-fix] Borracha não apaga elementos criados pelo Pincel dinâmico

### DIFF
--- a/js/tools/BorrachaTool.js
+++ b/js/tools/BorrachaTool.js
@@ -80,28 +80,17 @@ export class BorrachaTool extends ToolBase {
    * Apaga elementos atingidos por um segmento da trajetória
    */
   apagarSegmento(p1, p2) {
-    const distancia = Math.hypot(p2.x - p1.x, p2.y - p1.y);
-    const passos = Math.max(1, Math.ceil(distancia / 2));
+    const elementos = Array.from(this.svgCanvas.children);
 
-    for (let i = 0; i <= passos; i++) {
-      const t = i / passos;
+    for (const elemento of elementos) {
+      const tag = elemento.tagName?.toLowerCase();
 
-      const pontoSvg = this.svgCanvas.createSVGPoint();
-      pontoSvg.x = p1.x + (p2.x - p1.x) * t;
-      pontoSvg.y = p1.y + (p2.y - p1.y) * t;
+      if (!this.allowedTags.includes(tag)) {
+        continue;
+      }
 
-      const pontoTela = pontoSvg.matrixTransform(this.svgCanvas.getScreenCTM());
-      const elemento = document.elementFromPoint(pontoTela.x, pontoTela.y);
-
-      if (
-        elemento &&
-        elemento !== this.svgCanvas &&
-        (elemento.parentNode === this.svgCanvas || elemento.parentNode?.parentNode === this.svgCanvas)
-      ) {
-        const tag = elemento.tagName?.toLowerCase();
-        if (this.allowedTags.includes(tag)) {
-          elemento.remove();
-        }
+      if (this.segmentoInterceptaElemento(p1, p2, elemento)) {
+        elemento.remove();
       }
     }
   }

--- a/js/tools/BorrachaTool.js
+++ b/js/tools/BorrachaTool.js
@@ -96,7 +96,7 @@ export class BorrachaTool extends ToolBase {
       if (
         elemento &&
         elemento !== this.svgCanvas &&
-        elemento.parentNode === this.svgCanvas
+        (elemento.parentNode === this.svgCanvas || elemento.parentNode?.parentNode === this.svgCanvas)
       ) {
         const tag = elemento.tagName?.toLowerCase();
         if (this.allowedTags.includes(tag)) {
@@ -129,7 +129,8 @@ export class BorrachaTool extends ToolBase {
     if (
       elemento &&
       elemento !== this.svgCanvas &&
-      elemento.parentNode === this.svgCanvas &&
+      (elemento.parentNode === this.svgCanvas || elemento.parentNode?.parentNode === this.svgCanvas)
+      &&
       this.allowedTags.includes(tag)
     ) {
       elemento.remove();


### PR DESCRIPTION
## Problema

A ferramenta Borracha não removia elementos criados pelo Pincel dinâmico.

## Causa

A `BorrachaTool` verificava se o elemento era filho direto do `svgCanvas`:
```js
elemento.parentNode === this.svgCanvas
```
O `PincelTool` agrupa seus segmentos `<line>` dentro de um elemento `<g>`, tornando-os netos do canvas — não filhos diretos — o que fazia a verificação falhar.

## Correção

Adicionada verificação de dois níveis nos métodos `apagarSegmento` e `apagarNaPosicao`:
```js
elemento.parentNode === this.svgCanvas ||
elemento.parentNode?.parentNode === this.svgCanvas
```

## Arquivo modificado

- `js/tools/BorrachaTool.js`

Closes #167

@gustavoresque