### PR TITLE
feat: adiciona espelhamento para polígono/polilinha

### DIFF
--- a/js/utils/flipHelpers.js
+++ b/js/utils/flipHelpers.js
@@ -108,7 +108,8 @@ export function espelharHorizontal(elemento) {
         tag === "rect" ||
         tag === "path" ||
         tag === "circle" ||
-        tag === "ellipse"
+        tag === "ellipse" ||
+        tag === "polygon"
     ) {
         alternarEspelhamentoHorizontal(elemento);
         return;
@@ -140,7 +141,8 @@ export function espelharVertical(elemento) {
         tag === "rect" ||
         tag === "path" ||
         tag === "circle" ||
-        tag === "ellipse"
+        tag === "ellipse" ||
+        tag === "polygon"
     ) {
         alternarEspelhamentoVertical(elemento);
         return;


### PR DESCRIPTION
## O que foi feito

A opção do polígono/polilinha agora possui suporte a ferramenta de espelhamento, assim como as demais opções que já possuíam o devido suporte.

### Adições:

- Adiciona suporte ao espelhamento horizontal de polígonos;
- Adiciona suporte ao espelhamento vertical de polígonos;
- Mantém compatibilidade com a translação existente;
- Preserva o comportamento das demais formas.

Closes #245 

@gustavoresque 