### PR TITLE
188 padronizar icones

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -507,13 +507,13 @@ body {
 #zoom-options,
 #line-options {
   position: absolute;
-  background: var(--cor-fundo-barra);
+  background: var(--cor-fundo-painel);
   border: 1px solid var(--cor-borda-ui);
   box-shadow: var(--sombra-padrao);
   padding: 6px;
   border-radius: var(--raio-borda);
   flex-direction: column;
-  gap: 4px;
+  gap: 6px;
   z-index: 20;
 }
 
@@ -527,23 +527,57 @@ body {
   display: flex;
 }
 
-#zoom-options button,
 #line-options .btn-line-style {
-  background-color: #4a90d9;
-  width: 36px;
-  height: 36px;
-  border: 1px solid transparent;
+  width: 44px;
+  height: 34px;
+  background: var(--cor-fundo-app);
+  border: 1px solid var(--cor-borda-ui);
   border-radius: var(--raio-borda);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: border-color 0.15s ease, background-color 0.15s ease;
 }
 
-#zoom-options button:hover,
+#line-options .btn-line-style svg {
+  width: 30px;
+  height: 12px;
+}
+
+#line-options .btn-line-style line {
+  stroke: var(--cor-texto);
+  stroke-width: 2;
+}
+
 #line-options .btn-line-style:hover {
   border-color: var(--cor-destaque);
 }
 
-#zoom-options button.ativo,
 #line-options .btn-line-style.ativo {
-  background: rgba(0, 38, 255, 0.35);
+  background: rgba(74, 144, 217, 0.2);
+  border-color: var(--cor-destaque);
+}
+
+#line-options .btn-line-style.ativo line {
+  stroke: var(--cor-destaque);
+}
+
+#zoom-options button {
+  background-color: transparent;
+  width: 36px;
+  height: 36px;
+  border: 1px solid var(--cor-borda-ui);
+  border-radius: var(--raio-borda);
+  color: var(--cor-texto);
+}
+
+#zoom-options button:hover {
+  border-color: var(--cor-destaque);
+}
+
+#zoom-options button.ativo {
+  background: rgba(74, 144, 217, 0.2);
   border-color: var(--cor-destaque);
 }
 
@@ -873,4 +907,9 @@ body {
   display: block;
   width: 100%;
   height: 100%;
+}
+
+.btn-ferramenta i.ti {
+  font-size: 20px;
+  line-height: 1;
 }

--- a/css/style.css
+++ b/css/style.css
@@ -1040,7 +1040,6 @@ input[type="range"]::-moz-range-thumb {
 }
 
 .btn-line-style svg {
-<<<<<<< HEAD
   display: block;
   width: 100%;
   height: 100%;
@@ -1049,10 +1048,6 @@ input[type="range"]::-moz-range-thumb {
 .btn-ferramenta i.ti {
   font-size: 20px;
   line-height: 1;
-=======
-    display: block;
-    width: 100%;
-    height: 100%;
 }
 
 /* --- Indicador de Não Salvo --- */
@@ -1076,5 +1071,4 @@ input[type="range"]::-moz-range-thumb {
     display: flex !important;
     opacity: 0;
     visibility: hidden;
->>>>>>> main
 }

--- a/index.html
+++ b/index.html
@@ -246,26 +246,7 @@
           data-tooltip="Medidor (M)"
           title="Medidor (M)">
 
-          <svg xmlns="http://www.w3.org/2000/svg"
-              width="24"
-              height="24"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              stroke-width="2"
-              stroke-linecap="round"
-              stroke-linejoin="round">
-
-            <!-- Linha principal -->
-            <line x1="4" y1="18" x2="20" y2="6"/>
-
-            <!-- Marcações -->
-            <line x1="6" y1="17" x2="7" y2="16"/>
-            <line x1="9" y1="14" x2="10" y2="13"/>
-            <line x1="12" y1="11" x2="13" y2="10"/>
-            <line x1="15" y1="8" x2="16" y2="7"/>
-            <line x1="18" y1="5" x2="19" y2="4"/>
-          </svg>
+          <i class="ti ti-ruler-2"></i>
 
         </button>
       </aside>

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
   <title>Editor Vetorial — Computação Gráfica 2026</title>
   <link rel="stylesheet" href="css/style.css" />
   <link rel="stylesheet" href="css/contextMenu.css" />
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/driver.js/dist/driver.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@tabler/icons-webfont@latest/dist/tabler-icons.min.css" />
 </head>
 
 <body>
@@ -115,45 +115,39 @@
       <!-- Barra Lateral: botões das ferramentas de desenho -->
       <aside id="barra-ferramentas">
         <button id="btn-selecionar" class="btn-ferramenta" data-ferramenta="selecao" data-nome="Seleção" data-tooltip="Seleção (S)" title="Seleção (S)">
-          &#9654;
+          <i class="ti ti-pointer"></i>
         </button>
         <button id="btn-edicao-vertices" class="btn-ferramenta" data-ferramenta="edicaoVertices" data-nome="Edição de Vértices" data-tooltip="Edição de Vértices (V)" title="Edição de Vértices (V)">
-          &#9688;
+          <i class="ti ti-vector"></i>
         </button>
         <button id="btn-criar-retangulo" class="btn-ferramenta" data-ferramenta="retangulo" data-nome="Retângulo" data-tooltip="Retângulo (R)" title="Retângulo (R)">
-          &#9645;
+          <i class="ti ti-rectangle"></i>
         </button>
         <button id="btn-criar-losango" class="btn-ferramenta" data-ferramenta="losango" data-nome="Losango" data-tooltip="Losango (G)" title="Losango (G)">
-          &#9671;
+          <i class="ti ti-diamonds"></i>
         </button>
         <button id="btn-criar-elipse" class="btn-ferramenta" data-ferramenta="elipse" data-nome="Elipse" data-tooltip="Elipse (E)" title="Elipse (E)">
-          &#9711;
+          <i class="ti ti-circle"></i>
         </button>
         <div class="line-tool-group">
 
           <button id="btn-criar-linha" class="btn-ferramenta" data-ferramenta="linha" data-nome="Linha" data-tooltip="Linha (L)">
-            &#9135;
+            <i class="ti ti-line"></i>
           </button>
 
           <div id="line-options" class="hidden" aria-hidden="true">
             <div class="line-style-controls" aria-label="Estilo da linha">
 
               <button id="btn-line-continua" class="btn-line-style ativo" type="button" data-estilo-linha="continua" title="Linha contínua">
-                <svg viewBox="0 0 36 12" aria-hidden="true">
-                  <line x1="4" y1="6" x2="32" y2="6" />
-                </svg>
+                <i class="ti ti-minus"></i>
               </button>
 
               <button id="btn-line-tracejada" class="btn-line-style" type="button" data-estilo-linha="tracejada" title="Linha tracejada">
-                <svg viewBox="0 0 36 12" aria-hidden="true">
-                  <line x1="4" y1="6" x2="32" y2="6" stroke-dasharray="12 6" />
-                </svg>
+                <i class="ti ti-line-dashed"></i>
               </button>
 
               <button id="btn-line-pontilhada" class="btn-line-style" type="button" data-estilo-linha="pontilhada" title="Linha pontilhada">
-                <svg viewBox="0 0 36 12" aria-hidden="true">
-                  <line x1="4" y1="6" x2="32" y2="6" stroke-dasharray="1 6" stroke-linecap="round" />
-                </svg>
+                <i class="ti ti-line-dotted"></i>
               </button>
 
             </div>
@@ -161,72 +155,43 @@
 
         </div>
         <button id="btn-criar-linha-curvada" class="btn-ferramenta" data-ferramenta="linhaCurvada" data-nome="Linha Curvada" data-tooltip="Linha Curvada (C)" title="Linha Curvada (C)">
-          <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
-            aria-hidden="true" focusable="false">
-            <path d="M4 18C8 4 16 4 20 18" />
-          </svg>
+          <i class="ti ti-border-corner-pill"></i>
         </button>
         <button id="btn-criar-bezier" class="btn-ferramenta" data-ferramenta="bezier" data-nome="Bézier Cúbica" data-tooltip="Bézier Cúbica (Shift+C)" title="Bézier Cúbica (Shift+C)">
-          <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
-            aria-hidden="true" focusable="false">
-            <path d="M4 18C7 6 17 6 20 18" />
-            <circle cx="7" cy="6" r="1.5" />
-            <circle cx="17" cy="6" r="1.5" />
-          </svg>
+          <i class="ti ti-vector-bezier"></i>
         </button>
         <button id="btn-criar-espiral" class="btn-ferramenta" data-ferramenta="espiral" data-nome="Espiral" data-tooltip="Espiral (Shift+E)" title="Espiral (Shift+E)">
-          <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
-            aria-hidden="true" focusable="false">
-            <path d="M12 12m-1.5 0a1.5 1.5 0 1 0 3 0a1.5 1.5 0 1 0 -3 0" />
-            <path d="M12 12c3 0 4.5 2.2 3.2 4.4C13.6 19.2 8 18.8 6.2 15.2C3.8 10.5 8.2 5.5 13.4 6.2C18.8 6.9 21.4 12.4 19 17.2" />
-          </svg>
+          <i class="ti ti-spiral"></i>
         </button>
         <button id="btn-criar-polilinha" class="btn-ferramenta" data-ferramenta="poligono" data-nome="Polígono / Polilinha" data-tooltip="Polígono / Polilinha (G)" title="Polígono / Polilinha (G)">
-          &bowtie;
+          <i class="ti ti-polygon"></i>
         </button>
         <button id="btn-criar-texto" class="btn-ferramenta" data-ferramenta="texto" data-nome="Texto" data-tooltip="Texto (T)" title="Texto (T)">
-          T
+          <i class="ti ti-typography"></i>
         </button>
         <button id="btn-pintar" class="btn-ferramenta" data-ferramenta="Conta-gotas" data-nome="Conta-gotas" data-tooltip="Conta-gotas (I)" title="Conta-gotas (I)">
-          <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
-            class="lucide lucide-pipette-icon lucide-pipette">
-            <path d="m12 9-8.414 8.414A2 2 0 0 0 3 18.828v1.344a2 2 0 0 1-.586 1.414A2 2 0 0 1 3.828 21h1.344a2 2 0 0 0 1.414-.586L15 12" />
-            <path d="m18 9 .4.4a1 1 0 1 1-3 3l-3.8-3.8a1 1 0 1 1 3-3l.4.4 3.4-3.4a1 1 0 1 1 3 3z" />
-            <path d="m2 22 .414-.414" />
-          </svg>
+          <i class="ti ti-color-picker"></i>
         </button>
         <button id="btn-borracha" class="btn-ferramenta" data-ferramenta="borracha" data-nome="Borracha" data-tooltip="Borracha (B)" title="Borracha (B)">
-          <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-            <path d="M20 20H7L3 16L14 5L21 12L13 20" />
-          </svg>
+          <i class="ti ti-eraser"></i>
         </button>
 
         <button id="btn-lapis" class="btn-ferramenta" data-ferramenta="lapis" data-nome="Lápis" data-tooltip="Lápis (P)" title="Lápis (P)">
-          &#128393;
+          <i class="ti ti-pencil-minus"></i>
         </button>
 
         <button id="btn-pincel" class="btn-ferramenta" data-ferramenta="pincel" data-nome="Pincel" data-tooltip="Pincel dinâmico" title="Pincel dinâmico">
-          <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round" stroke-linecap="round">
-            <line x1="18" y1="2" x2="9" y2="11" />
-            <path d="M6 14 L9 11 L13 15 L10 18 Z" />
-            <path d="M10 18 Q8 21 6 22 Q7 20 6 14" />
-          </svg>
+          <i class="ti ti-brush"></i>
         </button>
 
         <button id="btn-zoom-click" class="btn-ferramenta" data-ferramenta="lupa" data-nome="Zoom" data-tooltip="Zoom (Z)" title="Zoom (Z)">
-          <svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-
-            <!-- lente -->
-            <circle cx="11" cy="11" r="7"></circle>
-            <!-- cabo -->
-            <line x1="21" y1="21" x2="16.65" y2="16.65"></line>
-
-          </svg>
+          <i class="ti ti-zoom"></i>
         </button>
+
         <div id="zoom-options" class="hidden"></div> <!-- Menu de opçoes para a lupa/zoom -->
 
         <button class="btn-ferramenta" id="btn-importar-imagem" data-nome="Importar Imagem" data-tooltip="Importar Imagem (Shift+I)" title="Importar Imagem (Shift+I)">
-          🖼️
+          <i class="ti ti-photo-up"></i>
         </button>
 
         <input type="file" id="input-imagem" accept="image/png, image/jpeg, image/svg+xml" style="display: none;" />


### PR DESCRIPTION
Substitui os ícones inconsistentes da barra de ferramentas esquerda por ícones do Tabler Icons (https://tabler.io/icons) conforme sugestão do professor. Também corrige o contraste do popup de opções de linha, que tinha uma cor de fundo que dificultava a visualização dos ícones.