### PR TITLE
Feat/243 adicionar preenchimento por gradiente

### DIFF
--- a/css/contextMenu.css
+++ b/css/contextMenu.css
@@ -133,6 +133,42 @@
   background: rgba(74, 144, 217, 0.15);
 }
 
+/* --- Preenchimento: alternador Sólida / Gradiente --- */
+
+.menu-contexto__fill-type-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 3px 10px;
+  margin-bottom: 2px;
+}
+
+.menu-contexto__fill-type-row label {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 10.5px;
+  color: var(--cor-texto-secundario);
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.menu-contexto__fill-type-row input[type="radio"] {
+  cursor: pointer;
+  accent-color: var(--cor-destaque);
+}
+
+.menu-contexto__gradiente-row {
+  gap: 14px;
+}
+
+.menu-contexto__gradiente-label {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 11px;
+  color: var(--cor-texto-secundario);
+}
+
 /* --- Estilo de borda (dash) --- */
 
 .menu-contexto__dash-opcoes {

--- a/css/style.css
+++ b/css/style.css
@@ -813,6 +813,41 @@ body {
   flex-wrap: wrap;
 }
 
+/* Alternador Sólido / Gradiente Linear / Gradiente Radial */
+.fill-type-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px 12px;
+  margin-bottom: 4px;
+}
+
+.fill-type-row label {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 11.5px;
+  color: var(--cor-texto-secundario);
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.fill-type-row input[type="radio"] {
+  cursor: pointer;
+  accent-color: var(--cor-destaque);
+}
+
+.gradiente-row {
+  gap: 16px;
+}
+
+.gradiente-stop-label {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  color: var(--cor-texto-secundario);
+}
+
 input[type="color"] {
   -webkit-appearance: none;
   appearance: none;

--- a/index.html
+++ b/index.html
@@ -257,10 +257,39 @@
 
             <div class="color-control-group">
               <span class="grupo-titulo">Preenchimento:</span>
-              <div class="color-row">
+
+              <div class="fill-type-row" role="radiogroup" aria-label="Tipo de preenchimento">
+                <label>
+                  <input type="radio" name="tipo-preenchimento" id="tipo-preenchimento-solido" value="solido" checked />
+                  Sólida
+                </label>
+                <label>
+                  <input type="radio" name="tipo-preenchimento" id="tipo-preenchimento-linear" value="linear" />
+                  Gradiente Linear
+                </label>
+                <label>
+                  <input type="radio" name="tipo-preenchimento" id="tipo-preenchimento-radial" value="radial" />
+                  Gradiente Radial
+                </label>
+              </div>
+
+              <div class="color-row" id="preenchimento-solido-row">
                 <input type="color" id="cor-preenchimento" value="#4a90d9" />
                 <button id="btn-preenchimento-nenhum" class="btn-color-none" title="Sem preenchimento" aria-label="Remover preenchimento">
               </button>
+              </div>
+
+              <div class="color-row gradiente-row oculto" id="preenchimento-gradiente-row">
+                <label class="gradiente-stop-label">
+                  De
+                  <input type="color" id="cor-gradiente-inicio" value="#4a90d9" />
+                </label>
+                <label class="gradiente-stop-label">
+                  Para
+                  <input type="color" id="cor-gradiente-fim" value="#ffffff" />
+                </label>
+              </div>
+
               <div class="opacity-slider-wrapper">
                 <label>
                   Opacidade:

--- a/js/contextMenu/builder.js
+++ b/js/contextMenu/builder.js
@@ -86,6 +86,14 @@ function criarAcaoBtn(texto, acao) {
   return btn;
 }
 
+function criarGradienteStopLabel(texto, inputColor) {
+  const lbl = document.createElement('label');
+  lbl.className = 'menu-contexto__gradiente-label';
+  lbl.appendChild(document.createTextNode(texto));
+  lbl.appendChild(inputColor);
+  return lbl;
+}
+
 // --- Builder principal ---
 
 /**
@@ -116,7 +124,41 @@ export function criarMenuContexto() {
   inputFill.type = 'color'; inputFill.value = '#4a90d9';
   const btnFillNone = criarBtnNone('Nenhum');
   const grupoFill = criarGrupo('Preenchimento');
-  grupoFill.appendChild(criarCorWrapper(inputFill, btnFillNone));
+
+  // Alternador Sólida / Gradiente Linear / Gradiente Radial
+  const radiosFillTipo = [];
+  const fillTypeRow = document.createElement('div');
+  fillTypeRow.className = 'menu-contexto__fill-type-row';
+  fillTypeRow.setAttribute('role', 'radiogroup');
+  fillTypeRow.setAttribute('aria-label', 'Tipo de preenchimento');
+  [['solido', 'Sólida'], ['linear', 'Linear'], ['radial', 'Radial']].forEach(([valor, label], i) => {
+    const lbl = document.createElement('label');
+    const radio = document.createElement('input');
+    radio.type = 'radio';
+    radio.name = 'menu-contexto-tipo-preenchimento';
+    radio.value = valor;
+    if (i === 0) radio.checked = true;
+    lbl.appendChild(radio);
+    lbl.appendChild(document.createTextNode(label));
+    fillTypeRow.appendChild(lbl);
+    radiosFillTipo.push(radio);
+  });
+  grupoFill.appendChild(fillTypeRow);
+
+  const corWrapperSolido = criarCorWrapper(inputFill, btnFillNone);
+  grupoFill.appendChild(corWrapperSolido);
+
+  const inputGradInicio = document.createElement('input');
+  inputGradInicio.type = 'color'; inputGradInicio.value = '#4a90d9';
+  const inputGradFim = document.createElement('input');
+  inputGradFim.type = 'color'; inputGradFim.value = '#ffffff';
+  const gradRow = document.createElement('div');
+  gradRow.className = 'menu-contexto__cor-wrapper menu-contexto__gradiente-row';
+  gradRow.hidden = true;
+  gradRow.appendChild(criarGradienteStopLabel('De', inputGradInicio));
+  gradRow.appendChild(criarGradienteStopLabel('Para', inputGradFim));
+  grupoFill.appendChild(gradRow);
+
   secaoEstilo.appendChild(grupoFill);
 
   const inputStroke = document.createElement('input');
@@ -190,6 +232,7 @@ export function criarMenuContexto() {
     menu,
     sliderOpacidade, valorOpacidade,
     inputFill, btnFillNone,
+    radiosFillTipo, corWrapperSolido, gradRow, inputGradInicio, inputGradFim,
     inputStroke, btnStrokeNone,
     sliderEspessura, valorEspessura,
     dashBtns,

--- a/js/contextMenu/index.js
+++ b/js/contextMenu/index.js
@@ -13,6 +13,7 @@
 import { registrarAcaoHistorico, definirElementosSelecionados } from "../core/StateManager.js";
 import { criarMenuContexto } from "./builder.js";
 import { sincronizarControles, normalizarHex } from "./sync.js";
+import { aplicarGradientePreenchimento } from "../utils/gradientHelpers.js";
 import {
   aplicarOffsetDuplicado,
   ordenarElemento,
@@ -63,6 +64,11 @@ export function inicializarMenuContexto(svgCanvas) {
     valorOpacidade,
     inputFill,
     btnFillNone,
+    radiosFillTipo,
+    corWrapperSolido,
+    gradRow,
+    inputGradInicio,
+    inputGradFim,
     inputStroke,
     btnStrokeNone,
     sliderEspessura,
@@ -89,6 +95,11 @@ export function inicializarMenuContexto(svgCanvas) {
     valorOpacidade,
     inputFill,
     btnFillNone,
+    radiosFillTipo,
+    corWrapperSolido,
+    gradRow,
+    inputGradInicio,
+    inputGradFim,
     inputStroke,
     btnStrokeNone,
     sliderEspessura,
@@ -129,7 +140,7 @@ export function inicializarMenuContexto(svgCanvas) {
     definirElementosSelecionados(alvo);
     elementoAtual = alvo;
     resetarBotaoExcluir();
-    sincronizarControles(elementoAtual, controles);
+    sincronizarControles(elementoAtual, controles, svgCanvas);
 
     // Posicionamento: torna visível fora da tela para medir dimensões
     menuContexto.hidden = false;
@@ -174,6 +185,42 @@ export function inicializarMenuContexto(svgCanvas) {
     valorOpacidade.textContent = `${sliderOpacidade.value}%`;
   });
 
+  /**
+   * Retorna o tipo de preenchimento selecionado no alternador do menu
+   * ('solido' | 'linear' | 'radial').
+   */
+  function tipoPreenchimentoSelecionado() {
+    const radioMarcado = radiosFillTipo.find((r) => r.checked);
+    return radioMarcado ? radioMarcado.value : "solido";
+  }
+
+  /**
+   * Aplica o preenchimento (cor sólida ou gradiente, conforme o alternador)
+   * ao elemento atualmente aberto no menu de contexto.
+   */
+  function aplicarPreenchimentoElementoAtual() {
+    if (!elementoAtual) return;
+
+    const tipo = tipoPreenchimentoSelecionado();
+
+    if (tipo === "solido") {
+      elementoAtual.setAttribute("fill", inputFill.value);
+    } else {
+      aplicarGradientePreenchimento(
+        svgCanvas,
+        elementoAtual,
+        tipo,
+        inputGradInicio.value,
+        inputGradFim.value,
+      );
+    }
+
+    btnFillNone.classList.remove("menu-contexto__none-btn--ativo");
+    inputFill.disabled = false;
+    corWrapperSolido.hidden = tipo !== "solido";
+    gradRow.hidden = tipo === "solido";
+  }
+
   inputFill.addEventListener("input", () => {
     if (!elementoAtual) return;
 
@@ -181,17 +228,24 @@ export function inicializarMenuContexto(svgCanvas) {
     btnFillNone.classList.remove("menu-contexto__none-btn--ativo");
   });
 
+  radiosFillTipo.forEach((radio) => {
+    radio.addEventListener("change", aplicarPreenchimentoElementoAtual);
+  });
+
+  inputGradInicio.addEventListener("input", aplicarPreenchimentoElementoAtual);
+  inputGradFim.addEventListener("input", aplicarPreenchimentoElementoAtual);
+
   btnFillNone.addEventListener("click", () => {
     if (!elementoAtual) return;
 
     if (elementoAtual.getAttribute("fill") === "none") {
-      elementoAtual.setAttribute("fill", inputFill.value);
-      btnFillNone.classList.remove("menu-contexto__none-btn--ativo");
-      inputFill.disabled = false;
+      aplicarPreenchimentoElementoAtual();
     } else {
       elementoAtual.setAttribute("fill", "none");
       btnFillNone.classList.add("menu-contexto__none-btn--ativo");
       inputFill.disabled = true;
+      corWrapperSolido.hidden = true;
+      gradRow.hidden = true;
     }
   });
 

--- a/js/contextMenu/sync.js
+++ b/js/contextMenu/sync.js
@@ -6,6 +6,8 @@
  * Sentido único: elemento → controles (sem efeitos colaterais no SVG).
  */
 
+import { ehGradiente, obterInfoGradiente } from "../utils/gradientHelpers.js";
+
 /**
  * Normaliza qualquer valor de cor SVG para formato #rrggbb,
  * compatível com input[type="color"].
@@ -25,15 +27,29 @@ export function normalizarHex(cor) {
 }
 
 /**
+ * Marca o rádio correspondente ao tipo de preenchimento ('solido' | 'linear' | 'radial').
+ *
+ * @param {HTMLInputElement[]} radios
+ * @param {string} tipo
+ */
+function definirTipoPreenchimentoRadio(radios, tipo) {
+  radios.forEach(radio => {
+    radio.checked = radio.value === tipo;
+  });
+}
+
+/**
  * Lê os atributos do elemento SVG e popula todos os controles do menu.
  *
  * @param {SVGElement} el - Elemento sendo inspecionado
  * @param {Object} controles - Referências ao DOM do menu (retorno de criarMenuContexto)
+ * @param {SVGSVGElement} [svgCanvas] - Canvas raiz, necessário para ler gradientes existentes
  */
-export function sincronizarControles(el, controles) {
+export function sincronizarControles(el, controles, svgCanvas) {
   const {
     sliderOpacidade, valorOpacidade,
     inputFill, btnFillNone,
+    radiosFillTipo, corWrapperSolido, gradRow, inputGradInicio, inputGradFim,
     inputStroke, btnStrokeNone,
     sliderEspessura, valorEspessura,
     dashBtns,
@@ -52,10 +68,27 @@ export function sincronizarControles(el, controles) {
   if (fill === 'none') {
     inputFill.disabled = true;
     btnFillNone.classList.add('menu-contexto__none-btn--ativo');
+    definirTipoPreenchimentoRadio(radiosFillTipo, 'solido');
+    corWrapperSolido.hidden = false;
+    gradRow.hidden = true;
+  } else if (ehGradiente(fill)) {
+    inputFill.disabled = false;
+    btnFillNone.classList.remove('menu-contexto__none-btn--ativo');
+    const info = svgCanvas ? obterInfoGradiente(svgCanvas, el) : null;
+    definirTipoPreenchimentoRadio(radiosFillTipo, info ? info.tipo : 'linear');
+    corWrapperSolido.hidden = true;
+    gradRow.hidden = false;
+    if (info) {
+      inputGradInicio.value = info.corInicio;
+      inputGradFim.value = info.corFim;
+    }
   } else {
     inputFill.disabled = false;
     btnFillNone.classList.remove('menu-contexto__none-btn--ativo');
     if (fill) inputFill.value = normalizarHex(fill);
+    definirTipoPreenchimentoRadio(radiosFillTipo, 'solido');
+    corWrapperSolido.hidden = false;
+    gradRow.hidden = true;
   }
 
   // Cor da borda

--- a/js/main.js
+++ b/js/main.js
@@ -54,7 +54,7 @@ import { agruparElementos, desagruparElementos } from './core/GroupManager.js';
 import { espelharHorizontal, espelharVertical } from "./utils/flipHelpers.js";
 import { salvarRascunho, marcarSalvo } from './utils/autoSave.js';
 import { ImageTracerManager } from './tools/ImageTracerManager.js';
-import { aplicarGradientePreenchimento, obterInfoGradiente, ehGradiente } from './utils/gradientHelpers.js';
+import { aplicarGradientePreenchimento, obterInfoGradiente, ehGradiente, definirGradientePadrao } from './utils/gradientHelpers.js';
 
 const svgCanvas = document.getElementById('canvas');
 
@@ -313,29 +313,43 @@ function atualizarVisibilidadeControlesPreenchimento(tipo) {
 
 /**
  * Aplica o preenchimento (sólido ou gradiente, conforme o tipo selecionado)
- * a todos os elementos atualmente selecionados.
+ * a todos os elementos atualmente selecionados. Se não houver nenhum
+ * elemento selecionado, apenas define o preenchimento "corrente", que será
+ * usado automaticamente pelas PRÓXIMAS formas desenhadas.
  */
 function aplicarPreenchimentoAtual() {
   const tipo = obterTipoPreenchimentoSelecionado();
-
-  if (estado.elementosSelecionados.length === 0) return;
+  const haSelecao = estado.elementosSelecionados.length > 0;
 
   if (tipo === 'solido') {
     const cor = inputCorPreenchimento.value;
     definirCorPreenchimento(cor);
-    estado.elementosSelecionados.forEach(el => el.setAttribute('fill', cor));
+    if (haSelecao) {
+      estado.elementosSelecionados.forEach(el => el.setAttribute('fill', cor));
+    }
   } else {
     const corInicio = inputCorGradienteInicio.value;
     const corFim = inputCorGradienteFim.value;
-    estado.elementosSelecionados.forEach(el => {
-      aplicarGradientePreenchimento(svgCanvas, el, tipo, corInicio, corFim);
-    });
+
+    if (haSelecao) {
+      // Cada elemento selecionado ganha (ou atualiza) seu próprio gradiente.
+      estado.elementosSelecionados.forEach(el => {
+        aplicarGradientePreenchimento(svgCanvas, el, tipo, corInicio, corFim);
+      });
+    } else {
+      // Sem seleção: define o gradiente como preenchimento padrão, para que
+      // a próxima forma desenhada já nasça com ele.
+      const referenciaGradiente = definirGradientePadrao(svgCanvas, tipo, corInicio, corFim);
+      definirCorPreenchimento(referenciaGradiente);
+    }
   }
 
-  registrarAcaoHistorico();
-  atualizarBotoesHistorico();
-  salvarRascunho(svgCanvas, estado, 'editor');
-  mostrarIndicadorNaoSalvo();
+  if (haSelecao) {
+    registrarAcaoHistorico();
+    atualizarBotoesHistorico();
+    salvarRascunho(svgCanvas, estado, 'editor');
+    mostrarIndicadorNaoSalvo();
+  }
 }
 
 radiosTipoPreenchimento.forEach(radio => {

--- a/js/main.js
+++ b/js/main.js
@@ -54,6 +54,7 @@ import { agruparElementos, desagruparElementos } from './core/GroupManager.js';
 import { espelharHorizontal, espelharVertical } from "./utils/flipHelpers.js";
 import { salvarRascunho, marcarSalvo } from './utils/autoSave.js';
 import { ImageTracerManager } from './tools/ImageTracerManager.js';
+import { aplicarGradientePreenchimento, obterInfoGradiente, ehGradiente } from './utils/gradientHelpers.js';
 
 const svgCanvas = document.getElementById('canvas');
 
@@ -73,6 +74,13 @@ const btnImportarImagem = document.getElementById('btn-importar-imagem');
 const inputImagem = document.getElementById('input-imagem');
 const inputCorPreenchimento = document.getElementById('cor-preenchimento');
 const inputCorBorda = document.getElementById('cor-borda');
+
+// Controles de tipo de preenchimento (sólido / gradiente linear / gradiente radial)
+const radiosTipoPreenchimento = document.querySelectorAll('input[name="tipo-preenchimento"]');
+const linhaPreenchimentoSolido = document.getElementById('preenchimento-solido-row');
+const linhaPreenchimentoGradiente = document.getElementById('preenchimento-gradiente-row');
+const inputCorGradienteInicio = document.getElementById('cor-gradiente-inicio');
+const inputCorGradienteFim = document.getElementById('cor-gradiente-fim');
 const botoesEstiloLinha = document.querySelectorAll('.btn-line-style');
 const nomeFerramenta = document.getElementById('nome-ferramenta');
 const btnExportar = document.getElementById('btn-exportar');
@@ -278,6 +286,68 @@ inputCorPreenchimento.addEventListener('input', () => {
   });
 });
 
+inputCorPreenchimento.addEventListener('change', () => {
+  registrarAcaoHistorico();
+  atualizarBotoesHistorico();
+});
+
+// --- Preenchimento em Gradiente (linear/radial) ---
+
+/**
+ * Retorna o tipo de preenchimento selecionado no rádio da sidebar
+ * ('solido' | 'linear' | 'radial').
+ */
+function obterTipoPreenchimentoSelecionado() {
+  const radioMarcado = Array.from(radiosTipoPreenchimento).find(r => r.checked);
+  return radioMarcado ? radioMarcado.value : 'solido';
+}
+
+/**
+ * Mostra/esconde as linhas de cor sólida x gradiente conforme o tipo escolhido.
+ */
+function atualizarVisibilidadeControlesPreenchimento(tipo) {
+  const ehGradienteSelecionado = tipo === 'linear' || tipo === 'radial';
+  linhaPreenchimentoSolido.classList.toggle('oculto', ehGradienteSelecionado);
+  linhaPreenchimentoGradiente.classList.toggle('oculto', !ehGradienteSelecionado);
+}
+
+/**
+ * Aplica o preenchimento (sólido ou gradiente, conforme o tipo selecionado)
+ * a todos os elementos atualmente selecionados.
+ */
+function aplicarPreenchimentoAtual() {
+  const tipo = obterTipoPreenchimentoSelecionado();
+
+  if (estado.elementosSelecionados.length === 0) return;
+
+  if (tipo === 'solido') {
+    const cor = inputCorPreenchimento.value;
+    definirCorPreenchimento(cor);
+    estado.elementosSelecionados.forEach(el => el.setAttribute('fill', cor));
+  } else {
+    const corInicio = inputCorGradienteInicio.value;
+    const corFim = inputCorGradienteFim.value;
+    estado.elementosSelecionados.forEach(el => {
+      aplicarGradientePreenchimento(svgCanvas, el, tipo, corInicio, corFim);
+    });
+  }
+
+  registrarAcaoHistorico();
+  atualizarBotoesHistorico();
+  salvarRascunho(svgCanvas, estado, 'editor');
+  mostrarIndicadorNaoSalvo();
+}
+
+radiosTipoPreenchimento.forEach(radio => {
+  radio.addEventListener('change', () => {
+    atualizarVisibilidadeControlesPreenchimento(radio.value);
+    aplicarPreenchimentoAtual();
+  });
+});
+
+inputCorGradienteInicio.addEventListener('input', aplicarPreenchimentoAtual);
+inputCorGradienteFim.addEventListener('input', aplicarPreenchimentoAtual);
+
 // Ouvir mudanças no input de cor de borda da sidebar
 inputCorBorda.addEventListener('input', () => {
   const novaCor = inputCorBorda.value;
@@ -325,6 +395,22 @@ svgCanvas.addEventListener('mouseup', (evento) => {
       inputCorBorda.value = corBordaAtual;
     }
 
+    // Se o preenchimento do objeto selecionado for um gradiente, sincroniza
+    // o alternador Sólido/Gradiente e os color-pickers "De"/"Para".
+    if (ehGradiente(corPreenchimentoAtual)) {
+      const infoGradiente = obterInfoGradiente(svgCanvas, primeiroSelecionado);
+      if (infoGradiente) {
+        const radioAlvo = document.getElementById(`tipo-preenchimento-${infoGradiente.tipo}`);
+        if (radioAlvo) radioAlvo.checked = true;
+        inputCorGradienteInicio.value = infoGradiente.corInicio;
+        inputCorGradienteFim.value = infoGradiente.corFim;
+        atualizarVisibilidadeControlesPreenchimento(infoGradiente.tipo);
+      }
+    } else {
+      document.getElementById('tipo-preenchimento-solido').checked = true;
+      atualizarVisibilidadeControlesPreenchimento('solido');
+    }
+
     // Atualiza visualmente os Sliders de Opacidade na UI
     sliderOpacidadePreenchimento.value = opacidadePreenchimentoAtual;
     sliderOpacidadeBorda.value = opacidadeBordaAtual;
@@ -345,6 +431,9 @@ btnPreenchimentoNenhum.addEventListener('click', () => {
   estado.elementosSelecionados.forEach(el => {
     el.setAttribute('fill', 'none');
   });
+
+  document.getElementById('tipo-preenchimento-solido').checked = true;
+  atualizarVisibilidadeControlesPreenchimento('solido');
   
   registrarAcaoHistorico();
   atualizarBotoesHistorico();

--- a/js/utils/gradientHelpers.js
+++ b/js/utils/gradientHelpers.js
@@ -14,6 +14,50 @@ const SVG_NS = "http://www.w3.org/2000/svg";
 const REGEX_URL_GRADIENTE = /^url\(#(.+)\)$/;
 
 let contador = 0;
+let idGradientePadrao = null;
+
+/**
+ * Cria/atualiza um único gradiente "padrão", usado como preenchimento
+ * corrente quando NÃO há nenhum objeto selecionado — é o que faz uma nova
+ * forma já nascer com gradiente, do mesmo jeito que hoje ela já nasce com
+ * a cor sólida escolhida no seletor.
+ *
+ * @param {SVGSVGElement} svgCanvas
+ * @param {'linear'|'radial'} tipo
+ * @param {string} corInicio
+ * @param {string} corFim
+ * @returns {string} valor pronto para usar em `fill`, ex: "url(#id)".
+ */
+export function definirGradientePadrao(svgCanvas, tipo, corInicio, corFim) {
+  const defs = obterOuCriarDefs(svgCanvas);
+  const tagEsperada = tipo === "radial" ? "radialGradient" : "linearGradient";
+
+  let gradienteEl = idGradientePadrao ? defs.querySelector(`#${CSS.escape(idGradientePadrao)}`) : null;
+
+  if (!gradienteEl || gradienteEl.tagName !== tagEsperada) {
+    if (gradienteEl) gradienteEl.remove();
+
+    idGradientePadrao = `gradiente-padrao-${Date.now()}-${contador++}`;
+    gradienteEl = document.createElementNS(SVG_NS, tagEsperada);
+    gradienteEl.setAttribute("id", idGradientePadrao);
+
+    if (tipo === "radial") {
+      gradienteEl.setAttribute("cx", "50%");
+      gradienteEl.setAttribute("cy", "50%");
+      gradienteEl.setAttribute("r", "50%");
+    } else {
+      gradienteEl.setAttribute("x1", "0%");
+      gradienteEl.setAttribute("y1", "0%");
+      gradienteEl.setAttribute("x2", "100%");
+      gradienteEl.setAttribute("y2", "0%");
+    }
+
+    defs.appendChild(gradienteEl);
+  }
+
+  atualizarStops(gradienteEl, corInicio, corFim);
+  return `url(#${idGradientePadrao})`;
+}
 
 /**
  * Retorna o <defs> do canvas, criando um novo (como primeiro filho) se

--- a/js/utils/gradientHelpers.js
+++ b/js/utils/gradientHelpers.js
@@ -1,0 +1,154 @@
+/**
+ * gradientHelpers.js — Utilitários para criação e edição de gradientes SVG
+ * (lineares e radiais) usados como preenchimento (fill) das formas.
+ *
+ * A ideia é simples: em vez de `fill="#4a90d9"`, o elemento passa a ter
+ * `fill="url(#gradiente-xxxx)"`, apontando para um `<linearGradient>` ou
+ * `<radialGradient>` guardado dentro de um `<defs>` no próprio `#canvas`.
+ *
+ * Cada elemento que usa gradiente possui seu PRÓPRIO gradiente (não
+ * compartilhado), assim editar as cores de um objeto nunca afeta outro.
+ */
+
+const SVG_NS = "http://www.w3.org/2000/svg";
+const REGEX_URL_GRADIENTE = /^url\(#(.+)\)$/;
+
+let contador = 0;
+
+/**
+ * Retorna o <defs> do canvas, criando um novo (como primeiro filho) se
+ * ainda não existir.
+ *
+ * @param {SVGSVGElement} svgCanvas
+ * @returns {SVGDefsElement}
+ */
+function obterOuCriarDefs(svgCanvas) {
+  let defs = svgCanvas.querySelector("defs");
+  if (!defs) {
+    defs = document.createElementNS(SVG_NS, "defs");
+    svgCanvas.insertBefore(defs, svgCanvas.firstChild);
+  }
+  return defs;
+}
+
+/**
+ * Extrai o id de um gradiente a partir do valor de um atributo `fill`
+ * (ex: "url(#gradiente-123)" -> "gradiente-123"). Retorna null se o valor
+ * não for uma referência de gradiente (cor sólida, "none", etc).
+ *
+ * @param {string} fill
+ * @returns {string|null}
+ */
+export function extrairIdGradiente(fill) {
+  if (!fill) return null;
+  const match = fill.match(REGEX_URL_GRADIENTE);
+  return match ? match[1] : null;
+}
+
+/**
+ * Cria (na primeira vez) ou reaproveita o gradiente já associado a um
+ * elemento, atualiza seu tipo/cores e aplica no atributo `fill` do elemento.
+ *
+ * @param {SVGSVGElement} svgCanvas - Canvas raiz (onde fica o <defs>).
+ * @param {SVGElement} elemento - Forma que vai receber o gradiente.
+ * @param {'linear'|'radial'} tipo
+ * @param {string} corInicio - Cor inicial em hexadecimal.
+ * @param {string} corFim - Cor final em hexadecimal.
+ * @returns {string} id do elemento de gradiente usado.
+ */
+export function aplicarGradientePreenchimento(svgCanvas, elemento, tipo, corInicio, corFim) {
+  const defs = obterOuCriarDefs(svgCanvas);
+  const tagEsperada = tipo === "radial" ? "radialGradient" : "linearGradient";
+
+  const idAtual = extrairIdGradiente(elemento.getAttribute("fill"));
+  let gradienteEl = idAtual ? defs.querySelector(`#${CSS.escape(idAtual)}`) : null;
+
+  // Se o elemento ainda não tinha gradiente próprio, ou o tipo mudou
+  // (linear <-> radial), criamos um elemento de gradiente novo.
+  if (!gradienteEl || gradienteEl.tagName !== tagEsperada) {
+    if (gradienteEl) gradienteEl.remove();
+
+    const novoId = `gradiente-${Date.now()}-${contador++}`;
+    gradienteEl = document.createElementNS(SVG_NS, tagEsperada);
+    gradienteEl.setAttribute("id", novoId);
+
+    if (tipo === "radial") {
+      gradienteEl.setAttribute("cx", "50%");
+      gradienteEl.setAttribute("cy", "50%");
+      gradienteEl.setAttribute("r", "50%");
+    } else {
+      gradienteEl.setAttribute("x1", "0%");
+      gradienteEl.setAttribute("y1", "0%");
+      gradienteEl.setAttribute("x2", "100%");
+      gradienteEl.setAttribute("y2", "0%");
+    }
+
+    defs.appendChild(gradienteEl);
+  }
+
+  atualizarStops(gradienteEl, corInicio, corFim);
+
+  const id = gradienteEl.getAttribute("id");
+  elemento.setAttribute("fill", `url(#${id})`);
+  return id;
+}
+
+/**
+ * Garante que o gradiente tenha exatamente dois <stop> (início/fim) e
+ * atualiza suas cores.
+ *
+ * @param {SVGElement} gradienteEl
+ * @param {string} corInicio
+ * @param {string} corFim
+ */
+function atualizarStops(gradienteEl, corInicio, corFim) {
+  let stops = gradienteEl.querySelectorAll("stop");
+
+  if (stops.length < 2) {
+    gradienteEl.textContent = "";
+    const stop1 = document.createElementNS(SVG_NS, "stop");
+    stop1.setAttribute("offset", "0%");
+    const stop2 = document.createElementNS(SVG_NS, "stop");
+    stop2.setAttribute("offset", "100%");
+    gradienteEl.appendChild(stop1);
+    gradienteEl.appendChild(stop2);
+    stops = gradienteEl.querySelectorAll("stop");
+  }
+
+  stops[0].setAttribute("stop-color", corInicio);
+  stops[stops.length - 1].setAttribute("stop-color", corFim);
+}
+
+/**
+ * Lê as informações do gradiente aplicado a um elemento (se houver),
+ * útil para repopular a UI quando o usuário seleciona um objeto.
+ *
+ * @param {SVGSVGElement} svgCanvas
+ * @param {SVGElement} elemento
+ * @returns {{tipo: 'linear'|'radial', corInicio: string, corFim: string}|null}
+ */
+export function obterInfoGradiente(svgCanvas, elemento) {
+  const id = extrairIdGradiente(elemento.getAttribute("fill"));
+  if (!id) return null;
+
+  const gradienteEl = svgCanvas.querySelector(`#${CSS.escape(id)}`);
+  if (!gradienteEl) return null;
+
+  const stops = gradienteEl.querySelectorAll("stop");
+  if (stops.length < 2) return null;
+
+  return {
+    tipo: gradienteEl.tagName === "radialGradient" ? "radial" : "linear",
+    corInicio: stops[0].getAttribute("stop-color") || "#000000",
+    corFim: stops[stops.length - 1].getAttribute("stop-color") || "#ffffff",
+  };
+}
+
+/**
+ * Diz se o valor de um atributo `fill` é uma referência a gradiente.
+ * @param {string} fill
+ * @returns {boolean}
+ */
+export function ehGradiente(fill) {
+  return extrairIdGradiente(fill) !== null;
+}


### PR DESCRIPTION
Arquivo novo:
js/utils/gradientHelpers.js

Módulo central com toda a lógica de gradientes SVG:
aplicarGradientePreenchimento() — cria/atualiza um gradiente (linear ou radial) próprio de um elemento, dentro de um <defs> no canvas.
definirGradientePadrao() — mantém um gradiente "corrente" compartilhado, usado como preenchimento padrão quando nenhum objeto está selecionado (para que novas formas já nasçam com gradiente).
obterInfoGradiente() — lê tipo e cores de um gradiente já aplicado a um elemento (para repopular a UI ao selecionar).
ehGradiente() / extrairIdGradiente() — helpers de detecção.

Painel lateral ("Estilo do Objeto"):
index.html — adicionado o alternador Sólida / Gradiente Linear / Gradiente Radial + dois color-pickers ("De"/"Para") no grupo de Preenchimento.
css/style.css — estilos do alternador e dos stops de cor.
js/main.js — conecta tudo:
Trocar o tipo ou as cores aplica o gradiente aos objetos selecionados.
Sem seleção, o gradiente vira o preenchimento padrão das próximas formas desenhadas.
Selecionar um objeto com gradiente sincroniza a UI automaticamente.
Integrado ao histórico (undo/redo) e ao auto-save.
"Sem preenchimento" volta o seletor para "Sólida".

Menu de contexto (botão direito no objeto):
js/contextMenu/builder.js — mesmo alternador Sólida/Linear/Radial + campos "De"/"Para", dentro do grupo "Preenchimento".
js/contextMenu/sync.js — ao abrir o menu, detecta se o objeto já tem gradiente e sincroniza tipo + cores; senão, mostra o modo sólido.
js/contextMenu/index.js — liga os novos controles: aplicar gradiente ao elemento aberto no menu, alternar sólido/gradiente, "Nenhum" restaura corretamente.
css/contextMenu.css — estilos correspondentes, no mesmo padrão visual do menu.