### PR TITLE
Fix de conflitos com a nova versão da main para controle de opacidade 

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1251,3 +1251,59 @@ input[type="range"]::-moz-range-thumb {
   opacity: 1;
   transform: translateY(-50%) translateX(0);
 }
+/*Controles de Opacidade e Feedback Alpha*/
+
+.opacity-slider-wrapper {
+  display: flex;
+  align-items: center;
+  flex: 1;
+  min-width: 140px;
+}
+
+.opacity-slider-wrapper label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  font-size: 12px;
+  color: var(--cor-texto-secundario);
+  white-space: nowrap;
+}
+
+/* Customização dos Sliders de Range */
+input[type="range"] {
+  -webkit-appearance: none;
+  appearance: none;
+  flex: 1;
+  height: 4px;
+  border-radius: 2px;
+  background: var(--cor-borda-ui);
+  accent-color: var(--cor-destaque);
+  cursor: pointer;
+}
+
+/* Estilização da Bolinha de Arraste (Navegadores Webkit) */
+input[type="range"]::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  width: 14px;
+  height: 16px;
+  border-radius: var(--raio-borda);
+  background: var(--cor-destaque);
+  border: 1px solid var(--cor-fundo-app);
+  cursor: pointer;
+  transition: transform 0.1s ease;
+}
+
+input[type="range"]::-webkit-slider-thumb:hover {
+  transform: scale(1.15);
+}
+
+/* Estilização da Bolinha de Arraste (Firefox) */
+input[type="range"]::-moz-range-thumb {
+  width: 14px;
+  height: 16px;
+  border-radius: var(--raio-borda);
+  background: var(--cor-destaque);
+  border: 1px solid var(--cor-fundo-app);
+  cursor: pointer;
+}

--- a/index.html
+++ b/index.html
@@ -194,7 +194,7 @@
         <button id="btn-criar-retangulo" class="btn-ferramenta" data-ferramenta="retangulo" data-nome="Retângulo" data-tooltip="Retângulo (R)" title="Retângulo (R)">
           <i class="ti ti-rectangle"></i>
         </button>
-<button id="btn-criar-losango" class="btn-ferramenta" data-ferramenta="losango" data-nome="Losango" data-tooltip="Losango (H)" title="Losango (H)">
+        <button id="btn-criar-losango" class="btn-ferramenta" data-ferramenta="losango" data-nome="Losango" data-tooltip="Losango (H)" title="Losango (H)">
           <i class="ti ti-diamonds"></i>
         </button>
         <button id="btn-criar-elipse" class="btn-ferramenta" data-ferramenta="elipse" data-nome="Elipse" data-tooltip="Elipse (E)" title="Elipse (E)">
@@ -254,7 +254,6 @@
         <button id="btn-pincel" class="btn-ferramenta" data-ferramenta="pincel" data-nome="Pincel" data-tooltip="Pincel dinâmico (D)" title="Pincel dinâmico (D)">
           <i class="ti ti-brush"></i>
         </button>
-        </button>
 
         <button id="btn-zoom-click" class="btn-ferramenta" data-ferramenta="lupa" data-nome="Zoom" data-tooltip="Zoom (Z)" title="Zoom (Z)">
           <i class="ti ti-zoom"></i>
@@ -305,43 +304,39 @@
               <span class="grupo-titulo">Preenchimento:</span>
               <div class="color-row">
                 <input type="color" id="cor-preenchimento" value="#4a90d9" />
-                <button id="btn-preenchimento-nenhum" class="btn-color-none" title="Sem preenchimento" aria-label="Remover preenchimento">
-              </button>
-              <div class="opacity-slider-wrapper">
-                <label>
-                  Opacidade:
-                  <input type="range" id="opacity-preenchimento" min="0" max="1" step="0.1" value="1" />
-                </label>
+                <button id="btn-preenchimento-nenhum" class="btn-color-none" title="Sem preenchimento" aria-label="Remover preenchimento">❌</button>
+                <div class="opacity-slider-wrapper">
+                  <label>
+                    Opacidade (<span id="val-opacity-fill">100%</span>):
+                    <input type="range" id="opacity-preenchimento" min="0" max="1" step="0.1" value="1" />
+                  </label>
+                </div>
               </div>
             </div>
-          </div>
-
 
             <div class="color-control-group" style="margin-top: 16px;">
               <span class="grupo-titulo">Borda:</span>
               <div class="color-row">
                 <input type="color" id="cor-borda" value="#1a1a2e" />
-                <button id="btn-borda-nenhum" class="btn-color-none" title="Sem borda" aria-label="Remover borda">
-              </button>
-              <div class="opacity-slider-wrapper">
-                <label>
-                  Opacidade:
-                  <input type="range" id="opacity-borda" min="0" max="1" step="0.1" value="1" />
-                </label>
+                <button id="btn-borda-nenhum" class="btn-color-none" title="Sem borda" aria-label="Remover borda">❌</button>
+                <div class="opacity-slider-wrapper">
+                  <label>
+                    Opacidade (<span id="val-opacity-stroke">100%</span>):
+                    <input type="range" id="opacity-borda" min="0" max="1" step="0.1" value="1" />
+                  </label>
+                </div>
               </div>
             </div>
-            <label> Espessura do Lápis:
-              <input type="range" id="espessura-lapis" min="1" max="100" value="2">
 
+            <label style="display: flex; align-items: center; gap: 10px; margin-top: 16px;"> Espessura do Lápis:
+              <input type="range" id="espessura-lapis" min="1" max="100" value="2">
               <span id="valor-espessura-lapis">2</span> px
             </label>
           </div>
 
           <div id="tab-tracer" class="tab-content" style="height: 100%; box-sizing: border-box;">
-
             <h3>Vetorizar Imagem</h3>
             
-            <!-- Estado vazio: Nenhuma imagem -->
             <div id="tracer-empty-state" class="oculto">
                 <p style="font-size: 0.9em; color: #666; margin-bottom: 10px;">
                     Nenhuma imagem rasterizada encontrada no canvas.
@@ -349,11 +344,9 @@
                 <button id="btn-tracer-importar" class="btn-menu">Importar Imagem</button>
             </div>
 
-            <!-- Lista de imagens e configurações -->
             <div id="tracer-conteudo">
                 <label class="propriedade-label">Selecione a imagem:</label>
                 <div id="tracer-lista-imagens" class="lista-imagens-container" style="max-height: 100px; overflow-y: auto; margin-bottom: 15px; border: 1px solid #ccc; padding: 5px;">
-                    <!-- Lista injetada via JS -->
                 </div>
 
                 <label for="tracer-preset" class="propriedade-label">Predefinição de estilo:</label>
@@ -370,9 +363,7 @@
                     </svg>
                 </div>
 
-                <!-- Painel de Configurações Avançadas (Ocupa o espaço restante e rola internamente) -->
                 <div id="tracer-advanced-panel" style="display: none; border-top: 1px solid #ddd; padding-top: 10px; margin-bottom: 15px; flex: 1; min-height: 0; overflow-y: auto; padding-right: 5px;">
-                    
                     <h4 style="margin: 5px 0; font-size: 0.9em; color: #4a90d9; text-transform: uppercase; letter-spacing: 0.5px;">Paleta de Cores</h4>
                     <div style="margin-bottom: 10px;">
                         <label style="display:block; font-size:0.85em; margin-bottom: 4px;">Máx. de Cores: <strong id="val-tracer-colors">16</strong></label>
@@ -398,7 +389,7 @@
                     </div>
                     <div style="margin-bottom: 10px; display: flex; align-items: center; gap: 6px;">
                         <input type="checkbox" id="tracer-rightangle" style="cursor: pointer;">
-                        <label for="tracer-rightangle" style="font-size:0.85em; cursor:pointer; user-select: none;">Forçar/Realçar ângulos retos</label>
+                        <label for="tracer-rightangle" style="font-size:0.85em; cursor:pointer; user-select: none;">Forçar/Realçar angles retos</label>
                     </div>
 
                     <h4 style="margin: 15px 0 5px 0; font-size: 0.9em; color: #4a90d9; text-transform: uppercase; letter-spacing: 0.5px;">Filtros (Pré-processo)</h4>

--- a/index.html
+++ b/index.html
@@ -304,14 +304,25 @@
               <span class="grupo-titulo">Preenchimento:</span>
               <div class="color-row">
                 <input type="color" id="cor-preenchimento" value="#4a90d9" />
-                <button id="btn-preenchimento-nenhum" class="btn-color-none" title="Sem preenchimento" aria-label="Remover preenchimento">❌</button>
-                <div class="opacity-slider-wrapper">
-                  <label>
-                    Opacidade (<span id="val-opacity-fill">100%</span>):
-                    <input type="range" id="opacity-preenchimento" min="0" max="1" step="0.1" value="1" />
-                  </label>
-                </div>
-              </div>
+            <button id="btn-preenchimento-nenhum" class="btn-color-none" title="Sem preenchimento" aria-label="Remover preenchimento"></button>
+            </div>
+
+            <div class="color-row gradiente-row oculto" id="preenchimento-gradiente-row">
+              <label class="gradiente-stop-label">
+                De
+                <input type="color" id="cor-gradiente-inicio" value="#4a90d9" />
+              </label>
+              <label class="gradiente-stop-label">
+                Para
+                <input type="color" id="cor-gradiente-fim" value="#ffffff" />
+              </label>
+            </div>
+
+            <div class="opacity-slider-wrapper">
+              <label>
+                Opacidade (<span id="val-opacity-fill">100%</span>):
+                <input type="range" id="opacity-preenchimento" min="0" max="1" step="0.1" value="1" />
+              </label>
             </div>
 
             <div class="color-control-group" style="margin-top: 16px;">

--- a/js/core/StateManager.js
+++ b/js/core/StateManager.js
@@ -13,13 +13,15 @@
  * - interfaceAtual {string}         - Flag para sabermos a tela onde o usuário está.
  */
 
-/** @type {{ ferramentaAtual: import('../tools/ToolBase.js').ToolBase|null, corPreenchimento: string, corBorda: string, estiloLinha: string, elementosSelecionados: SVGElement[], interfaceAtual: string }} */
+/** @type {{ ferramentaAtual: import('../tools/ToolBase.js').ToolBase|null, corPreenchimento: string, corBorda: string, opacidadePreenchimento: string, opacidadeBorda: string, estiloLinha: string, elementosSelecionados: SVGElement[], interfaceAtual: string }} */
 export const estado = {
   ferramentaAtual: null,
   corPreenchimento: '#4a90d9',
   corBorda: '#1a1a2e',
+  opacidadePreenchimento: '1', // Adicionado: 100% opaco por padrão
+  opacidadeBorda: '1',        // Adicionado: 100% opaco por padrão
   estiloLinha: 'continua',
-  interfaceAtual: 'inicio', // Nova flag para sabermos onde o usuário está
+  interfaceAtual: 'inicio', 
   elementosSelecionados: [],
   espessuraLapis: 2,
 };
@@ -196,4 +198,20 @@ export function desfazerAcao() {
 
 export function refazerAcao() {
   if (gerenciadorHistorico) gerenciadorHistorico.refazer();
+}
+
+/**
+ * Define a opacidade do preenchimento ativa.
+ * @param {string|number} opacidade - Valor entre '0' e '1'
+ */
+export function definirOpacidadePreenchimento(opacidade) {
+  estado.opacidadePreenchimento = String(opacidade);
+}
+
+/**
+ * Define a opacidade da borda ativa.
+ * @param {string|number} opacidade - Valor entre '0' e '1'
+ */
+export function definirOpacidadeBorda(opacidade) {
+  estado.opacidadeBorda = String(opacidade);
 }

--- a/js/main.js
+++ b/js/main.js
@@ -12,6 +12,8 @@ import {
   definirFerramenta,
   definirCorPreenchimento,
   definirCorBorda,
+  definirOpacidadePreenchimento,
+  definirOpacidadeBorda,
   definirEstiloLinha,
   definirGerenciadorSelecao,
   definirElementosSelecionados,
@@ -98,6 +100,7 @@ const nomeFerramenta = document.getElementById("nome-ferramenta");
 const btnExportar = document.getElementById("btn-exportar");
 const exportFormat = document.getElementById("export-format");
 const inputEspessuraLapis = document.getElementById("espessura-lapis");
+
 
 const indicadorNaoSalvo = document.getElementById("indicador-nao-salvo");
 function mostrarIndicadorNaoSalvo() {
@@ -342,16 +345,27 @@ function sincronizarInputsCores(elementos) {
   const fill = normalizarCorHex(el.getAttribute('fill'), estado.corPreenchimento);
   const stroke = normalizarCorHex(el.getAttribute('stroke'), estado.corBorda);
   const strokeWidth = el.getAttribute('stroke-width') || '2';
+  const fillOpacity = el.getAttribute('fill-opacity') || '1';
+  const strokeOpacity = el.getAttribute('stroke-opacity') || '1';
 
   popupCorPreenchimento.value = fill;
   popupCorBorda.value = stroke;
   inputCorPreenchimento.value = fill;
   inputCorBorda.value = stroke;
   popupStrokeWidth.value = strokeWidth;
+  
+  // Atualiza sliders e labels
+  if (sliderOpacidadePreenchimento) sliderOpacidadePreenchimento.value = fillOpacity;
+  if (sliderOpacidadeBorda) sliderOpacidadeBorda.value = strokeOpacity;
+  if (txtOpacidadePreenchimento) txtOpacidadePreenchimento.textContent = `${Math.round(fillOpacity * 100)}%`;
+  if (txtOpacidadeBorda) txtOpacidadeBorda.textContent = `${Math.round(strokeOpacity * 100)}%`;
+  
   atualizarBotaoEstiloAtivo(detectarEstiloBorda(el));
 
   definirCorPreenchimento(fill);
   definirCorBorda(stroke);
+  definirOpacidadePreenchimento(fillOpacity);
+  definirOpacidadeBorda(strokeOpacity);
 }
 
 document.addEventListener('selecao-mudou', (e) => {
@@ -444,32 +458,27 @@ svgCanvas.addEventListener("mouseup", (evento) => {
   if (primeiroSelecionado) {
     const corPreenchimentoAtual = primeiroSelecionado.getAttribute('fill') || '#ffffff';
     const corBordaAtual = primeiroSelecionado.getAttribute('stroke') || '#000000';
-    
-    // Captura as opacidades existentes (padrão é 1 se não houver atributo)
     const opacidadePreenchimentoAtual = primeiroSelecionado.getAttribute('fill-opacity') || '1';
     const opacidadeBordaAtual = primeiroSelecionado.getAttribute('stroke-opacity') || '1';
 
-    // Só atualizamos os seletores visuais do HTML se o valor do SVG for uma cor hexadecimal válida.
-    if (
-      corPreenchimentoAtual !== "none" &&
-      corPreenchimentoAtual.startsWith("#")
-    ) {
+    if (corPreenchimentoAtual !== "none" && corPreenchimentoAtual.startsWith("#")) {
       inputCorPreenchimento.value = corPreenchimentoAtual;
     }
     if (corBordaAtual !== "none" && corBordaAtual.startsWith("#")) {
       inputCorBorda.value = corBordaAtual;
     }
 
-    // Atualiza visualmente os Sliders de Opacidade na UI
-    sliderOpacidadePreenchimento.value = opacidadePreenchimentoAtual;
-    sliderOpacidadeBorda.value = opacidadeBordaAtual;
+    if (sliderOpacidadePreenchimento) sliderOpacidadePreenchimento.value = opacidadePreenchimentoAtual;
+    if (sliderOpacidadeBorda) sliderOpacidadeBorda.value = opacidadeBordaAtual;
+    if (txtOpacidadePreenchimento) txtOpacidadePreenchimento.textContent = `${Math.round(opacidadePreenchimentoAtual * 100)}%`;
+    if (txtOpacidadeBorda) txtOpacidadeBorda.textContent = `${Math.round(opacidadeBordaAtual * 100)}%`;
 
-    // Atualiza também os valores armazenados no StateManager para consistência
     definirCorPreenchimento(corPreenchimentoAtual);
     definirCorBorda(corBordaAtual);
+    definirOpacidadePreenchimento(opacidadePreenchimentoAtual);
+    definirOpacidadeBorda(opacidadeBordaAtual);
   }
 
-  // Auto-save silencioso após cada ação de desenho concluída no canvas principal
   salvarRascunho(svgCanvas, estado, "editor");
   mostrarIndicadorNaoSalvo();
 });
@@ -495,6 +504,41 @@ btnBordaNenhum.addEventListener('click', () => {
   registrarAcaoHistorico();
   atualizarBotoesHistorico();
 });
+
+// listeners de opacidade
+if (sliderOpacidadePreenchimento) {
+  sliderOpacidadePreenchimento.addEventListener("input", () => {
+    const valor = sliderOpacidadePreenchimento.value;
+    definirOpacidadePreenchimento(valor);
+    if (txtOpacidadePreenchimento) txtOpacidadePreenchimento.textContent = `${Math.round(valor * 100)}%`;
+    
+    estado.elementosSelecionados.forEach(el => {
+      el.setAttribute('fill-opacity', valor);
+    });
+  });
+
+  sliderOpacidadePreenchimento.addEventListener('change', () => {
+    registrarAcaoHistorico();
+    atualizarBotoesHistorico();
+  });
+}
+
+if (sliderOpacidadeBorda) {
+  sliderOpacidadeBorda.addEventListener("input", () => {
+    const valor = sliderOpacidadeBorda.value;
+    definirOpacidadeBorda(valor);
+    if (txtOpacidadeBorda) txtOpacidadeBorda.textContent = `${Math.round(valor * 100)}%`;
+    
+    estado.elementosSelecionados.forEach(el => {
+      el.setAttribute('stroke-opacity', valor);
+    });
+  });
+
+  sliderOpacidadeBorda.addEventListener("change", () => {
+    registrarAcaoHistorico();
+    atualizarBotoesHistorico();
+  });
+}
 
 sliderOpacidadePreenchimento.addEventListener("input", () => {
   const valor = sliderOpacidadePreenchimento.value;
@@ -869,6 +913,9 @@ document.addEventListener('keydown', (evento) => {
     return;
   }
 });
+
+const txtOpacidadePreenchimento = document.getElementById('val-opacity-fill');
+const txtOpacidadeBorda = document.getElementById('val-opacity-stroke');
 
 // Importação de imagens
 btnImportarImagem.addEventListener("click", () => {

--- a/js/main.js
+++ b/js/main.js
@@ -494,11 +494,39 @@ svgCanvas.addEventListener("mouseup", (evento) => {
       inputCorBorda.value = corBordaAtual;
     }
 
-    if (sliderOpacidadePreenchimento) sliderOpacidadePreenchimento.value = opacidadePreenchimentoAtual;
-    if (sliderOpacidadeBorda) sliderOpacidadeBorda.value = opacidadeBordaAtual;
-    if (txtOpacidadePreenchimento) txtOpacidadePreenchimento.textContent = `${Math.round(opacidadePreenchimentoAtual * 100)}%`;
-    if (txtOpacidadeBorda) txtOpacidadeBorda.textContent = `${Math.round(opacidadeBordaAtual * 100)}%`;
+    // Se o preenchimento do objeto selecionado for um gradiente, sincroniza
+    // o alternador Sólido/Gradiente e os color-pickers "De"/"Para".
+    if (typeof ehGradiente === 'function' && ehGradiente(corPreenchimentoAtual)) {
+      const infoGradiente = obterInfoGradiente(svgCanvas, primeiroSelecionado);
+      if (infoGradiente) {
+        const radioAlvo = document.getElementById(`tipo-preenchimento-${infoGradiente.tipo}`);
+        if (radioAlvo) radioAlvo.checked = true;
+        if (inputCorGradienteInicio) inputCorGradienteInicio.value = infoGradiente.corInicio;
+        if (inputCorGradienteFim) inputCorGradienteFim.value = infoGradiente.corFim;
+        atualizarVisibilidadeControlesPreenchimento(infoGradiente.tipo);
+      }
+    } else {
+      const radioSolido = document.getElementById("tipo-preenchimento-solido");
+      if (radioSolido) radioSolido.checked = true;
+      if (typeof atualizarVisibilidadeControlesPreenchimento === 'function') {
+        atualizarVisibilidadeControlesPreenchimento("solido");
+      }
+    }
 
+    // Atualiza visualmente os Sliders de Opacidade na UI com segurança
+    if (sliderOpacidadePreenchimento) {
+      sliderOpacidadePreenchimento.value = opacidadePreenchimentoAtual;
+    }
+    if (sliderOpacidadeBorda) {
+      sliderOpacidadeBorda.value = opacidadeBordaAtual;
+    }
+    if (txtOpacidadePreenchimento) {
+      txtOpacidadePreenchimento.textContent = `${Math.round(opacidadePreenchimentoAtual * 100)}%`;
+    }
+    if (txtOpacidadeBorda) {
+      txtOpacidadeBorda.textContent = `${Math.round(opacidadeBordaAtual * 100)}%`;
+    }
+    
     definirCorPreenchimento(corPreenchimentoAtual);
     definirCorBorda(corBordaAtual);
     definirOpacidadePreenchimento(opacidadePreenchimentoAtual);

--- a/js/main.js
+++ b/js/main.js
@@ -354,12 +354,38 @@ function sincronizarInputsCores(elementos) {
   inputCorBorda.value = stroke;
   popupStrokeWidth.value = strokeWidth;
   
-  // Atualiza sliders e labels
-  if (sliderOpacidadePreenchimento) sliderOpacidadePreenchimento.value = fillOpacity;
-  if (sliderOpacidadeBorda) sliderOpacidadeBorda.value = strokeOpacity;
-  if (txtOpacidadePreenchimento) txtOpacidadePreenchimento.textContent = `${Math.round(fillOpacity * 100)}%`;
-  if (txtOpacidadeBorda) txtOpacidadeBorda.textContent = `${Math.round(strokeOpacity * 100)}%`;
-  
+// Se o preenchimento do objeto selecionado for um gradiente, sincroniza
+    // o alternador Sólido/Gradiente e os color-pickers "De"/"Para".
+    if (typeof ehGradiente === 'function' && ehGradiente(corPreenchimentoAtual)) {
+      const infoGradiente = obterInfoGradiente(svgCanvas, primeiroSelecionado);
+      if (infoGradiente) {
+        const radioAlvo = document.getElementById(`tipo-preenchimento-${infoGradiente.tipo}`);
+        if (radioAlvo) radioAlvo.checked = true;
+        if (inputCorGradienteInicio) inputCorGradienteInicio.value = infoGradiente.corInicio;
+        if (inputCorGradienteFim) inputCorGradienteFim.value = infoGradiente.corFim;
+        atualizarVisibilidadeControlesPreenchimento(infoGradiente.tipo);
+      }
+    } else {
+      const radioSolido = document.getElementById("tipo-preenchimento-solido");
+      if (radioSolido) radioSolido.checked = true;
+      if (typeof atualizarVisibilidadeControlesPreenchimento === 'function') {
+        atualizarVisibilidadeControlesPreenchimento("solido");
+      }
+    }
+
+    // Atualiza visualmente os Sliders de Opacidade na UI com segurança (sua branch)
+    if (sliderOpacidadePreenchimento) {
+      sliderOpacidadePreenchimento.value = opacidadePreenchimentoAtual;
+    }
+    if (sliderOpacidadeBorda) {
+      sliderOpacidadeBorda.value = opacidadeBordaAtual;
+    }
+    if (txtOpacidadePreenchimento) {
+      txtOpacidadePreenchimento.textContent = `${Math.round(opacidadePreenchimentoAtual * 100)}%`;
+    }
+    if (txtOpacidadeBorda) {
+      txtOpacidadeBorda.textContent = `${Math.round(opacidadeBordaAtual * 100)}%`;
+    }
   atualizarBotaoEstiloAtivo(detectarEstiloBorda(el));
 
   definirCorPreenchimento(fill);

--- a/js/tools/LosangoTool.js
+++ b/js/tools/LosangoTool.js
@@ -27,14 +27,16 @@ export class LosangoTool extends ToolBase {
     this.startY = pt.y;
 
     // Cria o elemento SVG <polygon> dinamicamente
-    this.losnElement = criarElementoSVG('polygon', {
+      this.losnElement = criarElementoSVG('polygon', {
       x: this.startX,
       y: this.startY,
       'data-shape': 'losango',
       width: 0,
       height: 0,
       fill: estado.corPreenchimento,
+      'fill-opacity': estado.opacidadePreenchimento || '1', 
       stroke: estado.corBorda,
+      'stroke-opacity': estado.opacidadeBorda || '1',     
       'stroke-width': 2
     });
 

--- a/js/tools/PoligonoPolilinhaTool.js
+++ b/js/tools/PoligonoPolilinhaTool.js
@@ -137,9 +137,11 @@ export class PoligonoPolilinhaTool extends ToolBase {
         const poligonoFinal = criarElementoSVG('polygon', {
             points: this.formatarPoints(),
             stroke: estado.corBorda,
+            'stroke-opacity': estado.opacidadeBorda || '1', 
             'stroke-width': 2,
             'data-shape': 'poligono',
-            fill: estado.corPreenchimento || 'transparent'
+            fill: estado.corPreenchimento,
+            'fill-opacity': estado.opacidadePreenchimento || '1' 
         });
 
         this.svgCanvas.appendChild(poligonoFinal);

--- a/js/tools/RetanguloTool.js
+++ b/js/tools/RetanguloTool.js
@@ -29,13 +29,15 @@ export class RetanguloTool extends ToolBase {
     this.startY = pt.y;
 
     // Cria o elemento SVG <rect> dinamicamente
-    this.rectElement = criarElementoSVG('rect', {
+      this.rectElement = criarElementoSVG('rect', {
       x: this.startX,
       y: this.startY,
       width: 0,
       height: 0,
       fill: estado.corPreenchimento,
+      'fill-opacity': estado.opacidadePreenchimento || '1', 
       stroke: estado.corBorda,
+      'stroke-opacity': estado.opacidadeBorda || '1',     
       'stroke-width': 2
     });
 


### PR DESCRIPTION
Controle Alpha (Opacidade):

Integração completa dos sliders de range de opacidade para preenchimento (#opacity-preenchimento) e borda (#opacity-borda).

Atualização dinâmica em tempo real do feedback de texto com a porcentagem do canal Alpha correspondente (#val-opacity-fill e #val-opacity-stroke).

Sincronização bidirecional: ao selecionar um elemento no canvas, os sliders e labels de opacidade na barra lateral agora refletem fielmente os atributos fill-opacity e stroke-opacity do elemento selecionado.

Registro de histórico (HistoryManager) configurado para salvar o estado do canvas de forma otimizada (apenas no evento change, evitando sobrecarregar a pilha de Undo/Redo durante o arraste contínuo do slider).