### PR TITLE
Subindo feature de histórico de cores

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1366,3 +1366,23 @@ input[type="range"]::-moz-range-thumb {
   border: 1px solid var(--cor-fundo-app);
   cursor: pointer;
 }
+
+/* histórico de cores */
+.cor-recente-item {
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  border: 1px solid var(--cor-borda-ui);
+  cursor: pointer;
+  transition: transform 0.1s ease, border-color 0.15s ease;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.2);
+}
+
+.cor-recente-item:hover {
+  transform: scale(1.15);
+  border-color: var(--cor-destaque);
+}
+
+.cor-recente-item:active {
+  transform: scale(0.95);
+}

--- a/index.html
+++ b/index.html
@@ -370,6 +370,12 @@
             </label>
           </div>
 
+          <div class="color-control-group" style="margin-top: 16px;">
+            <span class="grupo-titulo">Cores Recentes:</span>
+             <div id="cores-recentes-container" style="display: flex; gap: 6px; flex-wrap: wrap; margin-top: 4px;">
+            </div>
+          </div>
+
           <div id="tab-tracer" class="tab-content" style="height: 100%; box-sizing: border-box;">
             <h3>Vetorizar Imagem</h3>
             

--- a/js/core/StateManager.js
+++ b/js/core/StateManager.js
@@ -24,6 +24,7 @@ export const estado = {
   interfaceAtual: 'inicio', 
   elementosSelecionados: [],
   espessuraLapis: 2,
+  coresRecentes: [],
 };
 
 let gerenciadorSelecaoVisual = null;
@@ -214,4 +215,30 @@ export function definirOpacidadePreenchimento(opacidade) {
  */
 export function definirOpacidadeBorda(opacidade) {
   estado.opacidadeBorda = String(opacidade);
+}
+
+/**
+ * Adiciona uma cor ao histórico de recentes se ela já não for a última adicionada.
+ * @param {string} cor - Hexadecimal da cor
+ */
+export function adicionarCorRecente(cor) {
+  if (!cor || cor === 'none' || cor === 'transparent') return;
+  
+  cor = cor.toLowerCase();
+  
+  // Remove a cor se ela já existir na lista (para movê-la para o topo)
+  estado.coresRecentes = estado.coresRecentes.filter(c => c !== cor);
+  
+  // Adiciona no início da lista
+  estado.coresRecentes.unshift(cor);
+  
+  // Limita o histórico a, por exemplo, 10 cores
+  if (estado.coresRecentes.length > 10) {
+    estado.coresRecentes.pop();
+  }
+
+  // Dispara um evento para avisar a UI que a lista mudou
+  document.dispatchEvent(new CustomEvent('cores-recentes-mudou', {
+    detail: { cores: estado.coresRecentes }
+  }));
 }

--- a/js/main.js
+++ b/js/main.js
@@ -24,6 +24,7 @@ import {
   definirCallbackPainelAlinhamento,
   atualizarPosicaoSelecaoVisual,
   definirEspessuraLapis,
+  adicionarCorRecente, 
 } from "./core/StateManager.js";
 import { rgbToHex } from "./utils/colorHelpers.js";
 import { ColorPickerTool } from "./tools/ColorPickerTool.js";
@@ -1162,6 +1163,66 @@ if (tabTracer) {
     });
     observerTab.observe(tabTracer, { attributes: true, attributeFilter: ['class'] });
 }
+
+const containerCoresRecentes = document.getElementById("cores-recentes-container");
+
+// Função para renderizar os quadradinhos de cores na tela
+function renderizarCoresRecentes(cores) {
+  if (!containerCoresRecentes) return;
+  
+  containerCoresRecentes.innerHTML = ""; // Limpa a UI antiga
+  
+  cores.forEach(cor => {
+    const botaoCor = document.createElement("button");
+    botaoCor.className = "cor-recente-item";
+    botaoCor.style.backgroundColor = cor;
+    botaoCor.title = `Aplicar cor ${cor}`;
+    
+    // Quando o usuário clicar na cor recente
+    botaoCor.addEventListener("click", () => {
+      // 1. Atualiza as variáveis de estado de cor ativa
+      definirCorPreenchimento(cor);
+      
+      // 2. Atualiza os inputs de cor da UI para o usuário ver a mudança
+      if (inputCorPreenchimento) inputCorPreenchimento.value = cor;
+      if (popupCorPreenchimento) popupCorPreenchimento.value = cor;
+      
+      // 3. Se houver elementos selecionados, aplica a cor neles
+      estado.elementosSelecionados.forEach(el => {
+        el.setAttribute("fill", cor);
+      });
+      
+      // Salva a alteração no histórico de edição do canvas
+      registrarAcaoHistorico();
+      atualizarBotoesHistorico();
+    });
+    
+    containerCoresRecentes.appendChild(botaoCor);
+  });
+}
+
+// Escuta as atualizações do estado para redesenhar a UI
+document.addEventListener('cores-recentes-mudou', (e) => {
+  renderizarCoresRecentes(e.detail.cores);
+});
+
+// Captura quando o usuário altera a cor no input principal para salvar no histórico
+inputCorPreenchimento.addEventListener("change", () => {
+  adicionarCorRecente(inputCorPreenchimento.value);
+});
+
+inputCorBorda.addEventListener("change", () => {
+  adicionarCorRecente(inputCorBorda.value);
+});
+
+// Captura também as mudanças que vêm do popup flutuante
+popupCorPreenchimento.addEventListener("change", () => {
+  adicionarCorRecente(popupCorPreenchimento.value);
+});
+
+popupCorBorda.addEventListener("change", () => {
+  adicionarCorRecente(popupCorBorda.value);
+});
 
 // Inicializar o estado dos botões de histórico
 atualizarBotoesHistorico();

--- a/js/main.js
+++ b/js/main.js
@@ -1166,7 +1166,7 @@ if (tabTracer) {
 
 const containerCoresRecentes = document.getElementById("cores-recentes-container");
 
-// Função para renderizar os quadradinhos de cores na tela
+// 1. Função de Renderização Corrigida (com "Ar" e verificações robustas)
 function renderizarCoresRecentes(cores) {
   if (!containerCoresRecentes) return;
   
@@ -1176,31 +1176,41 @@ function renderizarCoresRecentes(cores) {
     const botaoCor = document.createElement("button");
     botaoCor.className = "cor-recente-item";
     botaoCor.style.backgroundColor = cor;
-    botaoCor.title = `Aplicar cor ${cor}`;
     
-    // Quando o usuário clicar na cor recente
-    botaoCor.addEventListener("click", () => {
-      // 1. Atualiza as variáveis de estado de cor ativa
-      definirCorPreenchimento(cor);
+    // Tooltip com dica de usabilidade
+    botaoCor.title = `Cor ${cor}\n• Clique para Preenchimento\n• Shift + Clique para Borda`;
+    
+    botaoCor.addEventListener("click", (evento) => {
+      const eBorda = evento.shiftKey;
       
-      // 2. Atualiza os inputs de cor da UI para o usuário ver a mudança
-      if (inputCorPreenchimento) inputCorPreenchimento.value = cor;
-      if (popupCorPreenchimento) popupCorPreenchimento.value = cor;
+      if (eBorda) {
+        // Aplica na Borda
+        definirCorBorda(cor);
+        if (inputCorBorda) inputCorBorda.value = cor;
+        if (popupCorBorda) popupCorBorda.value = cor;
+        
+        estado.elementosSelecionados.forEach(el => {
+          el.setAttribute("stroke", cor);
+        });
+      } else {
+        // Aplica no Preenchimento
+        definirCorPreenchimento(cor);
+        if (inputCorPreenchimento) inputCorPreenchimento.value = cor;
+        if (popupCorPreenchimento) popupCorPreenchimento.value = cor;
+        
+        estado.elementosSelecionados.forEach(el => {
+          el.setAttribute("fill", cor);
+        });
+      }
       
-      // 3. Se houver elementos selecionados, aplica a cor neles
-      estado.elementosSelecionados.forEach(el => {
-        el.setAttribute("fill", cor);
-      });
-      
-      // Salva a alteração no histórico de edição do canvas
-      registrarAcaoHistorico();
-      atualizarBotoesHistorico();
+      // Salva no histórico de ações do canvas
+      if (typeof registrarAcaoHistorico === 'function') registrarAcaoHistorico();
+      if (typeof atualizarBotoesHistorico === 'function') atualizarBotoesHistorico();
     });
     
     containerCoresRecentes.appendChild(botaoCor);
   });
 }
-
 // Escuta as atualizações do estado para redesenhar a UI
 document.addEventListener('cores-recentes-mudou', (e) => {
   renderizarCoresRecentes(e.detail.cores);
@@ -1223,7 +1233,6 @@ popupCorPreenchimento.addEventListener("change", () => {
 popupCorBorda.addEventListener("change", () => {
   adicionarCorRecente(popupCorBorda.value);
 });
-
 // Inicializar o estado dos botões de histórico
 atualizarBotoesHistorico();
 


### PR DESCRIPTION
Este PR implementa a funcionalidade de Cores Recentes no painel lateral de estilos. Agora, sempre que o usuário escolher uma cor (seja para preenchimento ou borda), ela é adicionada a um histórico de cores recentes interativo, permitindo a reutilização rápida de paletas personalizadas durante a edição.

- Histórico Dinâmico de Cores (UI): Adicionado um novo grupo chamado "Cores Recentes" na aba Estilo (#cores-recentes-container), que exibe até 10 cores únicas utilizadas recentemente na sessão.

- Interatividade Touch/Click: Ao clicar em qualquer círculo do histórico, a cor selecionada é instantaneamente aplicada como preenchimento nos elementos ativos no canvas e atualiza os seletores de cor correspondentes na interface.

- Clique simples na cor do histórico: Transfere a cor selecionada para a cor de preenchimento do polígono/linha

- Shift + Clique na cor do histórico: Transfere a cor selecionada para a cor da borda do polígono/linha