### PR TITLE
Feat: adiciona espelhamento horizontal e vertical ao Pincel Dinâmico

### DIFF
--- a/js/tools/PincelTool.js
+++ b/js/tools/PincelTool.js
@@ -44,6 +44,7 @@ export class PincelTool extends ToolBase {
 
         // Agrupa todos os segmentos do traço em um único <g>
         this.grupo = document.createElementNS(SVG_NS, 'g');
+        this.grupo.dataset.shape = 'pincel';
         this.grupo.setAttribute('stroke-linecap', 'round');
         this.svgCanvas.appendChild(this.grupo);
     }

--- a/js/utils/flipHelpers.js
+++ b/js/utils/flipHelpers.js
@@ -109,7 +109,8 @@ export function espelharHorizontal(elemento) {
         tag === "path" ||
         tag === "circle" ||
         tag === "ellipse" ||
-        tag === "polygon"
+        tag === "polygon" ||
+        (tag === "g" && elemento.dataset.shape === "pincel")
     ) {
         alternarEspelhamentoHorizontal(elemento);
         return;
@@ -142,7 +143,8 @@ export function espelharVertical(elemento) {
         tag === "path" ||
         tag === "circle" ||
         tag === "ellipse" ||
-        tag === "polygon"
+        tag === "polygon" ||
+        (tag === "g" && elemento.dataset.shape === "pincel")
     ) {
         alternarEspelhamentoVertical(elemento);
         return;


### PR DESCRIPTION
## O que foi feito

- adiciona suporte ao espelhamento horizontal do Pincel Dinâmico;
- adiciona suporte ao espelhamento vertical do Pincel Dinâmico;
- identifica os grupos do pincel com `data-shape="pincel"`;
- reutiliza a infraestrutura existente de transformação em `flipHelpers`.

## Testes realizados

- [x] Criação de objeto com pincel
- [x] Seleção
- [x] Arrastar
- [x] Espelhamento horizontal
- [x] Espelhamento vertical
- [x] Movimentação após espelhamento

A issue atribuída a este PR é tratada como bug fix mas na ocasião em que a ferramenta de espelhamento era desenvolvida junto com o pincel dinâmico, quando este ainda era rudimentar e sequer podia ser arrastado pelo canvas. Por isso aqui, essa implementação é tratada como uma feature após melhorias do pincel.

Closes #184

@gustavoresque 